### PR TITLE
Support leading '.' in type names

### DIFF
--- a/field_test.ts
+++ b/field_test.ts
@@ -19,6 +19,19 @@ Deno.test("Field", async () => {
       2,
     ],
     [
+      `.Foo bar = 1;`,
+      new Field(
+        ".Foo",
+        "bar",
+        1,
+        {},
+        [],
+        [1, 1],
+        [1, 13],
+      ),
+      2,
+    ],
+    [
       `foo.bar nested_message = 2;`,
       new Field(
         "foo.bar",

--- a/proto_test.ts
+++ b/proto_test.ts
@@ -33,3 +33,4 @@ Deno.test(testFile(`test2`, 2));
 Deno.test(testFile(`test1`, 2));
 Deno.test(testFile(`rpc1`, 2));
 Deno.test(testFile(`comments`, 2, { comments: true }));
+Deno.test(testFile(`leadingdot`, 2, { write: true }));

--- a/protoscanner.ts
+++ b/protoscanner.ts
@@ -43,7 +43,7 @@ export function protoScanner(
     mode: defaultTokens | (comments ? scanComments : 0),
     isIdent(ch: string, i: number) {
       return (ch >= "A" && ch <= "Z") || (ch >= "a" && ch <= "z") ||
-        (i > 0 && ((ch >= "0" && ch <= "9") || ch === "_" || ch === "."));
+        (i > 0 && ((ch >= "0" && ch <= "9") || ch === "_") || ch === ".");
     },
     isBinary: () => false,
     isKeyword(ident: string) {

--- a/testdata/leadingdot.ast.json
+++ b/testdata/leadingdot.ast.json
@@ -1,0 +1,70 @@
+{
+  "type": "Proto",
+  "start": [
+    1,
+    1
+  ],
+  "end": [
+    7,
+    0
+  ],
+  "body": [
+    {
+      "type": "Syntax",
+      "start": [
+        1,
+        1
+      ],
+      "end": [
+        1,
+        18
+      ],
+      "version": 3
+    },
+    {
+      "type": "Message",
+      "start": [
+        3,
+        1
+      ],
+      "end": [
+        6,
+        1
+      ],
+      "name": "Foo",
+      "body": [
+        {
+          "type": "Message",
+          "start": [
+            4,
+            3
+          ],
+          "end": [
+            4,
+            16
+          ],
+          "name": "Bar",
+          "body": []
+        },
+        {
+          "type": "Field",
+          "start": [
+            5,
+            12
+          ],
+          "end": [
+            5,
+            30
+          ],
+          "fieldType": ".Foo.Bar",
+          "name": "thing",
+          "id": 1,
+          "options": [],
+          "repeated": true,
+          "optional": false,
+          "required": false
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/leadingdot.proto
+++ b/testdata/leadingdot.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+message Foo {
+  message Bar {}
+  repeated .Foo.Bar thing = 1;
+}


### PR DESCRIPTION
This solution deviates from the spec since neither `ident` nor `fullIdent` has an optional leading '.', only `messageType` and `enumType` do. Another approach is to parse the dot separately and concatenate it with the remaining identifier, but I don't see that done anywhere else in the project.