### PR TITLE
Fix Option parser

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -5,4 +5,4 @@ export {
   scanComments,
   nextTokenIs,
   TokenError,
-} from "https://deno.land/x/scanner@v0.1.2/mod.ts";
+} from "https://deno.land/x/scanner@v0.2.0/mod.ts";

--- a/field.ts
+++ b/field.ts
@@ -107,7 +107,7 @@ export class Field extends ParseNode {
         type: "Field",
         start: this.start,
         end: this.end,
-        fieldType: this.fieldType,
+        fieldType: this.fieldType.toJSON(),
         name: this.name,
         id: this.id,
         options: this.options.map((node) => node.toJSON()),

--- a/field_test.ts
+++ b/field_test.ts
@@ -1,5 +1,6 @@
 import { assertNode, assertNodeThrows } from "./testutil.ts";
 import { Field } from "./field.ts";
+import { Type } from "./type.ts";
 import { FieldOption } from "./fieldoption.ts";
 import { Constant } from "./constant.ts";
 
@@ -8,7 +9,11 @@ Deno.test("Field", async () => {
     [
       `optional float F_Ninf = 16;`,
       new Field(
-        "float",
+        new Type(
+          "float",
+          [1, 10],
+          [1, 14]
+        ),
         "F_Ninf",
         16,
         { optional: true },
@@ -21,7 +26,11 @@ Deno.test("Field", async () => {
     [
       `.Foo bar = 1;`,
       new Field(
-        ".Foo",
+        new Type(
+          ".Foo",
+          [1, 1],
+          [1, 4]
+        ),
         "bar",
         1,
         {},
@@ -34,7 +43,11 @@ Deno.test("Field", async () => {
     [
       `foo.bar nested_message = 2;`,
       new Field(
-        "foo.bar",
+        new Type(
+          "foo.bar",
+          [1, 1],
+          [1, 7],
+        ),
         "nested_message",
         2,
         {},
@@ -47,7 +60,11 @@ Deno.test("Field", async () => {
     [
       `repeated int32 samples = 4 [packed = true];`,
       new Field(
-        "int32",
+        new Type(
+          "int32",
+          [1, 10],
+          [1, 14],
+        ),
         "samples",
         4,
         { repeated: true },
@@ -68,7 +85,11 @@ Deno.test("Field", async () => {
     [
       `repeated int32 samples = 4 [(some.nested).key = true];`,
       new Field(
-        "int32",
+        new Type(
+          "int32",
+          [1, 10],
+          [1, 14],
+        ),
         "samples",
         4,
         { repeated: true },

--- a/field_test.ts
+++ b/field_test.ts
@@ -12,7 +12,7 @@ Deno.test("Field", async () => {
         new Type(
           "float",
           [1, 10],
-          [1, 14]
+          [1, 14],
         ),
         "F_Ninf",
         16,
@@ -29,7 +29,7 @@ Deno.test("Field", async () => {
         new Type(
           ".Foo",
           [1, 1],
-          [1, 4]
+          [1, 4],
         ),
         "bar",
         1,

--- a/mapfield.ts
+++ b/mapfield.ts
@@ -61,7 +61,7 @@ export class MapField extends ParseNode {
       start: this.start,
       end: this.end,
       keyType: KeyType[this.keyType],
-      valueType: this.valueType,
+      valueType: this.valueType.toJSON(),
       name: this.name,
       id: this.id,
     };

--- a/mapfield_test.ts
+++ b/mapfield_test.ts
@@ -1,11 +1,19 @@
 import { assertNode, assertNodeThrows } from "./testutil.ts";
 import { MapField } from "./mapfield.ts";
+import { Type } from "./type.ts";
 
 Deno.test("MapField", async () => {
   const tt: [string, MapField, 2 | 3][] = [
     [
       `map<int32, bar> foo = 3;`,
-      new MapField("int32", "bar", "foo", 3, [1, 1], [1, 24]),
+      new MapField(
+        "int32",
+        new Type("bar", [1, 12], [1, 14]),
+        "foo",
+        3,
+        [1, 1],
+        [1, 24],
+      ),
       2,
     ],
   ];

--- a/protoscanner.ts
+++ b/protoscanner.ts
@@ -43,7 +43,7 @@ export function protoScanner(
     mode: defaultTokens | (comments ? scanComments : 0),
     isIdent(ch: string, i: number) {
       return (ch >= "A" && ch <= "Z") || (ch >= "a" && ch <= "z") ||
-        (i > 0 && ((ch >= "0" && ch <= "9") || ch === "_") || ch === ".");
+        (i > 0 && ((ch >= "0" && ch <= "9") || ch === "_" || ch === "."));
     },
     isBinary: () => false,
     isKeyword(ident: string) {

--- a/rpc.ts
+++ b/rpc.ts
@@ -78,8 +78,14 @@ export class RPC extends ParseNode {
         start: this.start,
         end: this.end,
         name: this.name,
-        request: this.request,
-        response: this.response,
+        request: {
+          name: this.request.name.toJSON(),
+          streaming: this.request.streaming,
+        },
+        response: {
+          name: this.response.name.toJSON(),
+          streaming: this.response.streaming,
+        },
         body: this.body?.map((node) => node.toJSON()) || null,
       },
       this.comments.length

--- a/rpc.ts
+++ b/rpc.ts
@@ -2,6 +2,7 @@ import { ParseNode } from "./parsenode.ts";
 import { Visitor } from "./visitor.ts";
 import { Scanner, Token, nextTokenIs, TokenError } from "./deps.ts";
 import { expectSimpleIdent, assignComments } from "./util.ts";
+import { Type } from "./type.ts";
 import { Option } from "./option.ts";
 import { Comment } from "./comment.ts";
 
@@ -20,12 +21,12 @@ export class RPC extends ParseNode {
      * The identifier of the Request object, and whether or not this is
      * streaming.
      */
-    public request: { name: string; streaming?: boolean },
+    public request: { name: Type; streaming?: boolean },
     /**
      * The identifier of the Resonse object, and whether or not this is
      * streaming.
      */
-    public response: { name: string; streaming?: boolean },
+    public response: { name: Type; streaming?: boolean },
     /**
      * A collection of direct child nodes in the RPC definition.
      */
@@ -62,11 +63,11 @@ export class RPC extends ParseNode {
       }\n}`;
     }
     const request = this.request.streaming
-      ? `stream ${this.request.name}`
-      : this.request.name;
+      ? `stream ${this.request.name.toProto()}`
+      : this.request.name.toProto();
     const response = this.response.streaming
-      ? `stream ${this.response.name}`
-      : this.response.name;
+      ? `stream ${this.response.name.toProto()}`
+      : this.response.name.toProto();
     return `${comments}rpc ${this.name} (${request}) returns (${response})${body}`;
   }
 
@@ -90,6 +91,8 @@ export class RPC extends ParseNode {
   accept(visitor: Visitor) {
     visitor.visit?.(this);
     visitor.visitRPC?.(this);
+    this.request.name.accept(visitor);
+    this.response.name.accept(visitor);
     for (const node of this.body || []) node.accept(visitor);
     for (const node of this.comments) node.accept(visitor);
   }
@@ -102,23 +105,23 @@ export class RPC extends ParseNode {
     const name = await expectSimpleIdent(scanner);
     await nextTokenIs(scanner, Token.token, "(");
     const request = {
-      name: await nextTokenIs(scanner, Token.identifier),
+      name: await Type.parse(scanner),
       streaming: false,
     };
-    if (request.name === "stream") {
+    if (request.name.name === "stream") {
       request.streaming = true;
-      request.name = await nextTokenIs(scanner, Token.identifier);
+      request.name = await Type.parse(scanner);
     }
     await nextTokenIs(scanner, Token.token, ")");
     await nextTokenIs(scanner, Token.keyword, "returns");
     await nextTokenIs(scanner, Token.token, "(");
     const response = {
-      name: await nextTokenIs(scanner, Token.identifier),
+      name: await Type.parse(scanner),
       streaming: false,
     };
-    if (response.name === "stream") {
+    if (response.name.name === "stream") {
       response.streaming = true;
-      response.name = await nextTokenIs(scanner, Token.identifier);
+      response.name = await Type.parse(scanner);
     }
     await nextTokenIs(scanner, Token.token, ")");
 

--- a/rpc_test.ts
+++ b/rpc_test.ts
@@ -1,15 +1,16 @@
 import { assertNode, assertNodeThrows } from "./testutil.ts";
 import { RPC } from "./rpc.ts";
+import { Type } from "./type.ts";
 
 Deno.test("RPC", async () => {
   const tt: [string, RPC][] = [
     [
       `rpc Foo (Req) returns (Res) {}`,
-      new RPC("Foo", { name: "Req" }, { name: "Res" }, [], [1, 1], [1, 30]),
+      new RPC("Foo", { name: new Type("Req", [1, 10], [1, 12]) }, { name: new Type("Res", [1, 24], [1, 26]) }, [], [1, 1], [1, 30]),
     ],
     [
       `rpc Foo (Req) returns (Res);`,
-      new RPC("Foo", { name: "Req" }, { name: "Res" }, null, [1, 1], [1, 28]),
+      new RPC("Foo", { name: new Type("Req", [1, 10], [1, 12]) }, { name: new Type("Res", [1, 24], [1, 26]) }, null, [1, 1], [1, 28]),
     ],
   ];
   for (const t of tt) await assertNode(RPC, ...t);

--- a/rpc_test.ts
+++ b/rpc_test.ts
@@ -6,11 +6,25 @@ Deno.test("RPC", async () => {
   const tt: [string, RPC][] = [
     [
       `rpc Foo (Req) returns (Res) {}`,
-      new RPC("Foo", { name: new Type("Req", [1, 10], [1, 12]) }, { name: new Type("Res", [1, 24], [1, 26]) }, [], [1, 1], [1, 30]),
+      new RPC(
+        "Foo",
+        { name: new Type("Req", [1, 10], [1, 12]) },
+        { name: new Type("Res", [1, 24], [1, 26]) },
+        [],
+        [1, 1],
+        [1, 30],
+      ),
     ],
     [
       `rpc Foo (Req) returns (Res);`,
-      new RPC("Foo", { name: new Type("Req", [1, 10], [1, 12]) }, { name: new Type("Res", [1, 24], [1, 26]) }, null, [1, 1], [1, 28]),
+      new RPC(
+        "Foo",
+        { name: new Type("Req", [1, 10], [1, 12]) },
+        { name: new Type("Res", [1, 24], [1, 26]) },
+        null,
+        [1, 1],
+        [1, 28],
+      ),
     ],
   ];
   for (const t of tt) await assertNode(RPC, ...t);

--- a/testdata/comments.ast.json
+++ b/testdata/comments.ast.json
@@ -59,11 +59,33 @@
           ],
           "name": "MyMethod",
           "request": {
-            "name": "MyRequest",
+            "name": {
+              "type": "Type",
+              "start": [
+                14,
+                19
+              ],
+              "end": [
+                14,
+                27
+              ],
+              "name": "MyRequest"
+            },
             "streaming": false
           },
           "response": {
-            "name": "MyResponse",
+            "name": {
+              "type": "Type",
+              "start": [
+                14,
+                39
+              ],
+              "end": [
+                14,
+                48
+              ],
+              "name": "MyResponse"
+            },
             "streaming": false
           },
           "body": null,
@@ -106,7 +128,18 @@
             24,
             20
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              24,
+              5
+            ],
+            "end": [
+              24,
+              10
+            ],
+            "name": "string"
+          },
           "name": "path",
           "id": 1,
           "options": [],
@@ -166,7 +199,18 @@
             34,
             21
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              34,
+              5
+            ],
+            "end": [
+              34,
+              9
+            ],
+            "name": "int32"
+          },
           "name": "status",
           "id": 2,
           "options": [],

--- a/testdata/golang-jsonpb-test2.ast.json
+++ b/testdata/golang-jsonpb-test2.ast.json
@@ -152,7 +152,18 @@
             44,
             27
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              44,
+              12
+            ],
+            "end": [
+              44,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "o_bool",
           "id": 1,
           "options": [],
@@ -170,7 +181,18 @@
             45,
             29
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              45,
+              12
+            ],
+            "end": [
+              45,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "o_int32",
           "id": 2,
           "options": [],
@@ -188,7 +210,18 @@
             46,
             33
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              46,
+              12
+            ],
+            "end": [
+              46,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "o_int32_str",
           "id": 3,
           "options": [],
@@ -206,7 +239,18 @@
             47,
             29
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              47,
+              12
+            ],
+            "end": [
+              47,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "o_int64",
           "id": 4,
           "options": [],
@@ -224,7 +268,18 @@
             48,
             33
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              48,
+              12
+            ],
+            "end": [
+              48,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "o_int64_str",
           "id": 5,
           "options": [],
@@ -242,7 +297,18 @@
             49,
             31
           ],
-          "fieldType": "uint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              49,
+              12
+            ],
+            "end": [
+              49,
+              17
+            ],
+            "name": "uint32"
+          },
           "name": "o_uint32",
           "id": 6,
           "options": [],
@@ -260,7 +326,18 @@
             50,
             35
           ],
-          "fieldType": "uint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              50,
+              12
+            ],
+            "end": [
+              50,
+              17
+            ],
+            "name": "uint32"
+          },
           "name": "o_uint32_str",
           "id": 7,
           "options": [],
@@ -278,7 +355,18 @@
             51,
             31
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              51,
+              12
+            ],
+            "end": [
+              51,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "o_uint64",
           "id": 8,
           "options": [],
@@ -296,7 +384,18 @@
             52,
             35
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              52,
+              12
+            ],
+            "end": [
+              52,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "o_uint64_str",
           "id": 9,
           "options": [],
@@ -314,7 +413,18 @@
             53,
             32
           ],
-          "fieldType": "sint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              53,
+              12
+            ],
+            "end": [
+              53,
+              17
+            ],
+            "name": "sint32"
+          },
           "name": "o_sint32",
           "id": 10,
           "options": [],
@@ -332,7 +442,18 @@
             54,
             36
           ],
-          "fieldType": "sint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              54,
+              12
+            ],
+            "end": [
+              54,
+              17
+            ],
+            "name": "sint32"
+          },
           "name": "o_sint32_str",
           "id": 11,
           "options": [],
@@ -350,7 +471,18 @@
             55,
             32
           ],
-          "fieldType": "sint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              55,
+              12
+            ],
+            "end": [
+              55,
+              17
+            ],
+            "name": "sint64"
+          },
           "name": "o_sint64",
           "id": 12,
           "options": [],
@@ -368,7 +500,18 @@
             56,
             36
           ],
-          "fieldType": "sint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              56,
+              12
+            ],
+            "end": [
+              56,
+              17
+            ],
+            "name": "sint64"
+          },
           "name": "o_sint64_str",
           "id": 13,
           "options": [],
@@ -386,7 +529,18 @@
             57,
             30
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              57,
+              12
+            ],
+            "end": [
+              57,
+              16
+            ],
+            "name": "float"
+          },
           "name": "o_float",
           "id": 14,
           "options": [],
@@ -404,7 +558,18 @@
             58,
             34
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              58,
+              12
+            ],
+            "end": [
+              58,
+              16
+            ],
+            "name": "float"
+          },
           "name": "o_float_str",
           "id": 15,
           "options": [],
@@ -422,7 +587,18 @@
             59,
             32
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              59,
+              12
+            ],
+            "end": [
+              59,
+              17
+            ],
+            "name": "double"
+          },
           "name": "o_double",
           "id": 16,
           "options": [],
@@ -440,7 +616,18 @@
             60,
             36
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              60,
+              12
+            ],
+            "end": [
+              60,
+              17
+            ],
+            "name": "double"
+          },
           "name": "o_double_str",
           "id": 17,
           "options": [],
@@ -458,7 +645,18 @@
             61,
             32
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              61,
+              12
+            ],
+            "end": [
+              61,
+              17
+            ],
+            "name": "string"
+          },
           "name": "o_string",
           "id": 18,
           "options": [],
@@ -476,7 +674,18 @@
             62,
             30
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              62,
+              12
+            ],
+            "end": [
+              62,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "o_bytes",
           "id": 19,
           "options": [],
@@ -508,7 +717,18 @@
             67,
             29
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              67,
+              14
+            ],
+            "end": [
+              67,
+              18
+            ],
+            "name": "float"
+          },
           "name": "f_nan",
           "id": 1,
           "options": [],
@@ -526,7 +746,18 @@
             68,
             30
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              68,
+              14
+            ],
+            "end": [
+              68,
+              18
+            ],
+            "name": "float"
+          },
           "name": "f_pinf",
           "id": 2,
           "options": [],
@@ -544,7 +775,18 @@
             69,
             30
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              69,
+              14
+            ],
+            "end": [
+              69,
+              18
+            ],
+            "name": "float"
+          },
           "name": "f_ninf",
           "id": 3,
           "options": [],
@@ -562,7 +804,18 @@
             70,
             30
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              70,
+              14
+            ],
+            "end": [
+              70,
+              19
+            ],
+            "name": "double"
+          },
           "name": "d_nan",
           "id": 4,
           "options": [],
@@ -580,7 +833,18 @@
             71,
             31
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              71,
+              14
+            ],
+            "end": [
+              71,
+              19
+            ],
+            "name": "double"
+          },
           "name": "d_pinf",
           "id": 5,
           "options": [],
@@ -598,7 +862,18 @@
             72,
             31
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              72,
+              14
+            ],
+            "end": [
+              72,
+              19
+            ],
+            "name": "double"
+          },
           "name": "d_ninf",
           "id": 6,
           "options": [],
@@ -630,7 +905,18 @@
             77,
             27
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              77,
+              12
+            ],
+            "end": [
+              77,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "r_bool",
           "id": 1,
           "options": [],
@@ -648,7 +934,18 @@
             78,
             29
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              78,
+              12
+            ],
+            "end": [
+              78,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "r_int32",
           "id": 2,
           "options": [],
@@ -666,7 +963,18 @@
             79,
             29
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              79,
+              12
+            ],
+            "end": [
+              79,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "r_int64",
           "id": 3,
           "options": [],
@@ -684,7 +992,18 @@
             80,
             31
           ],
-          "fieldType": "uint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              80,
+              12
+            ],
+            "end": [
+              80,
+              17
+            ],
+            "name": "uint32"
+          },
           "name": "r_uint32",
           "id": 4,
           "options": [],
@@ -702,7 +1021,18 @@
             81,
             31
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              81,
+              12
+            ],
+            "end": [
+              81,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "r_uint64",
           "id": 5,
           "options": [],
@@ -720,7 +1050,18 @@
             82,
             31
           ],
-          "fieldType": "sint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              82,
+              12
+            ],
+            "end": [
+              82,
+              17
+            ],
+            "name": "sint32"
+          },
           "name": "r_sint32",
           "id": 6,
           "options": [],
@@ -738,7 +1079,18 @@
             83,
             31
           ],
-          "fieldType": "sint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              83,
+              12
+            ],
+            "end": [
+              83,
+              17
+            ],
+            "name": "sint64"
+          },
           "name": "r_sint64",
           "id": 7,
           "options": [],
@@ -756,7 +1108,18 @@
             84,
             29
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              84,
+              12
+            ],
+            "end": [
+              84,
+              16
+            ],
+            "name": "float"
+          },
           "name": "r_float",
           "id": 8,
           "options": [],
@@ -774,7 +1137,18 @@
             85,
             31
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              85,
+              12
+            ],
+            "end": [
+              85,
+              17
+            ],
+            "name": "double"
+          },
           "name": "r_double",
           "id": 9,
           "options": [],
@@ -792,7 +1166,18 @@
             86,
             32
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              86,
+              12
+            ],
+            "end": [
+              86,
+              17
+            ],
+            "name": "string"
+          },
           "name": "r_string",
           "id": 10,
           "options": [],
@@ -810,7 +1195,18 @@
             87,
             30
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              87,
+              12
+            ],
+            "end": [
+              87,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "r_bytes",
           "id": 11,
           "options": [],
@@ -895,7 +1291,18 @@
             97,
             27
           ],
-          "fieldType": "Color",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              97,
+              12
+            ],
+            "end": [
+              97,
+              16
+            ],
+            "name": "Color"
+          },
           "name": "color",
           "id": 1,
           "options": [],
@@ -913,7 +1320,18 @@
             98,
             29
           ],
-          "fieldType": "Color",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              98,
+              12
+            ],
+            "end": [
+              98,
+              16
+            ],
+            "name": "Color"
+          },
           "name": "r_color",
           "id": 2,
           "options": [],
@@ -931,7 +1349,18 @@
             100,
             30
           ],
-          "fieldType": "Simple",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              100,
+              12
+            ],
+            "end": [
+              100,
+              17
+            ],
+            "name": "Simple"
+          },
           "name": "simple",
           "id": 10,
           "options": [],
@@ -949,7 +1378,18 @@
             101,
             32
           ],
-          "fieldType": "Simple",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              101,
+              12
+            ],
+            "end": [
+              101,
+              17
+            ],
+            "name": "Simple"
+          },
           "name": "r_simple",
           "id": 11,
           "options": [],
@@ -967,7 +1407,18 @@
             103,
             32
           ],
-          "fieldType": "Repeats",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              103,
+              12
+            ],
+            "end": [
+              103,
+              18
+            ],
+            "name": "Repeats"
+          },
           "name": "repeats",
           "id": 20,
           "options": [],
@@ -985,7 +1436,18 @@
             104,
             34
           ],
-          "fieldType": "Repeats",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              104,
+              12
+            ],
+            "end": [
+              104,
+              18
+            ],
+            "name": "Repeats"
+          },
           "name": "r_repeats",
           "id": 21,
           "options": [],
@@ -1018,7 +1480,18 @@
             37
           ],
           "keyType": "int64",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              108,
+              14
+            ],
+            "end": [
+              108,
+              19
+            ],
+            "name": "string"
+          },
           "name": "m_int64_str",
           "id": 1
         },
@@ -1033,7 +1506,18 @@
             38
           ],
           "keyType": "bool",
-          "valueType": "Simple",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              109,
+              13
+            ],
+            "end": [
+              109,
+              18
+            ],
+            "name": "Simple"
+          },
           "name": "m_bool_simple",
           "id": 2
         }
@@ -1073,7 +1557,18 @@
                 114,
                 21
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  114,
+                  5
+                ],
+                "end": [
+                  114,
+                  10
+                ],
+                "name": "string"
+              },
               "name": "title",
               "id": 1,
               "options": [],
@@ -1091,7 +1586,18 @@
                 115,
                 21
               ],
-              "fieldType": "int64",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  115,
+                  5
+                ],
+                "end": [
+                  115,
+                  9
+                ],
+                "name": "int64"
+              },
               "name": "salary",
               "id": 2,
               "options": [],
@@ -1109,7 +1615,18 @@
                 116,
                 23
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  116,
+                  5
+                ],
+                "end": [
+                  116,
+                  10
+                ],
+                "name": "string"
+              },
               "name": "Country",
               "id": 3,
               "options": [],
@@ -1127,7 +1644,18 @@
                 117,
                 28
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  117,
+                  5
+                ],
+                "end": [
+                  117,
+                  10
+                ],
+                "name": "string"
+              },
               "name": "home_address",
               "id": 4,
               "options": [],
@@ -1145,7 +1673,18 @@
                 118,
                 42
               ],
-              "fieldType": "MsgWithRequired",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  118,
+                  5
+                ],
+                "end": [
+                  118,
+                  19
+                ],
+                "name": "MsgWithRequired"
+              },
               "name": "msg_with_required",
               "id": 5,
               "options": [],
@@ -1179,7 +1718,18 @@
             123,
             28
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              123,
+              12
+            ],
+            "end": [
+              123,
+              17
+            ],
+            "name": "double"
+          },
           "name": "value",
           "id": 1,
           "options": [],
@@ -1228,7 +1778,18 @@
             128,
             29
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              128,
+              12
+            ],
+            "end": [
+              128,
+              17
+            ],
+            "name": "string"
+          },
           "name": "name",
           "id": 124,
           "options": [],
@@ -1272,7 +1833,18 @@
                 133,
                 42
               ],
-              "fieldType": "Complex",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  133,
+                  14
+                ],
+                "end": [
+                  133,
+                  20
+                ],
+                "name": "Complex"
+              },
               "name": "real_extension",
               "id": 123,
               "options": [],
@@ -1292,7 +1864,18 @@
             135,
             32
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              135,
+              12
+            ],
+            "end": [
+              135,
+              17
+            ],
+            "name": "double"
+          },
           "name": "imaginary",
           "id": 1,
           "options": [],
@@ -1341,7 +1924,18 @@
             140,
             39
           ],
-          "fieldType": "google.protobuf.Any",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              140,
+              12
+            ],
+            "end": [
+              140,
+              30
+            ],
+            "name": "google.protobuf.Any"
+          },
           "name": "an",
           "id": 14,
           "options": [],
@@ -1359,7 +1953,18 @@
             141,
             44
           ],
-          "fieldType": "google.protobuf.Duration",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              141,
+              12
+            ],
+            "end": [
+              141,
+              35
+            ],
+            "name": "google.protobuf.Duration"
+          },
           "name": "dur",
           "id": 1,
           "options": [],
@@ -1377,7 +1982,18 @@
             142,
             42
           ],
-          "fieldType": "google.protobuf.Struct",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              142,
+              12
+            ],
+            "end": [
+              142,
+              33
+            ],
+            "name": "google.protobuf.Struct"
+          },
           "name": "st",
           "id": 12,
           "options": [],
@@ -1395,7 +2011,18 @@
             143,
             44
           ],
-          "fieldType": "google.protobuf.Timestamp",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              143,
+              12
+            ],
+            "end": [
+              143,
+              36
+            ],
+            "name": "google.protobuf.Timestamp"
+          },
           "name": "ts",
           "id": 2,
           "options": [],
@@ -1413,7 +2040,18 @@
             144,
             45
           ],
-          "fieldType": "google.protobuf.ListValue",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              144,
+              12
+            ],
+            "end": [
+              144,
+              36
+            ],
+            "name": "google.protobuf.ListValue"
+          },
           "name": "lv",
           "id": 15,
           "options": [],
@@ -1431,7 +2069,18 @@
             145,
             42
           ],
-          "fieldType": "google.protobuf.Value",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              145,
+              12
+            ],
+            "end": [
+              145,
+              32
+            ],
+            "name": "google.protobuf.Value"
+          },
           "name": "val",
           "id": 16,
           "options": [],
@@ -1449,7 +2098,18 @@
             147,
             47
           ],
-          "fieldType": "google.protobuf.DoubleValue",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              147,
+              12
+            ],
+            "end": [
+              147,
+              38
+            ],
+            "name": "google.protobuf.DoubleValue"
+          },
           "name": "dbl",
           "id": 3,
           "options": [],
@@ -1467,7 +2127,18 @@
             148,
             46
           ],
-          "fieldType": "google.protobuf.FloatValue",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              148,
+              12
+            ],
+            "end": [
+              148,
+              37
+            ],
+            "name": "google.protobuf.FloatValue"
+          },
           "name": "flt",
           "id": 4,
           "options": [],
@@ -1485,7 +2156,18 @@
             149,
             46
           ],
-          "fieldType": "google.protobuf.Int64Value",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              149,
+              12
+            ],
+            "end": [
+              149,
+              37
+            ],
+            "name": "google.protobuf.Int64Value"
+          },
           "name": "i64",
           "id": 5,
           "options": [],
@@ -1503,7 +2185,18 @@
             150,
             47
           ],
-          "fieldType": "google.protobuf.UInt64Value",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              150,
+              12
+            ],
+            "end": [
+              150,
+              38
+            ],
+            "name": "google.protobuf.UInt64Value"
+          },
           "name": "u64",
           "id": 6,
           "options": [],
@@ -1521,7 +2214,18 @@
             151,
             46
           ],
-          "fieldType": "google.protobuf.Int32Value",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              151,
+              12
+            ],
+            "end": [
+              151,
+              37
+            ],
+            "name": "google.protobuf.Int32Value"
+          },
           "name": "i32",
           "id": 7,
           "options": [],
@@ -1539,7 +2243,18 @@
             152,
             47
           ],
-          "fieldType": "google.protobuf.UInt32Value",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              152,
+              12
+            ],
+            "end": [
+              152,
+              38
+            ],
+            "name": "google.protobuf.UInt32Value"
+          },
           "name": "u32",
           "id": 8,
           "options": [],
@@ -1557,7 +2272,18 @@
             153,
             46
           ],
-          "fieldType": "google.protobuf.BoolValue",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              153,
+              12
+            ],
+            "end": [
+              153,
+              36
+            ],
+            "name": "google.protobuf.BoolValue"
+          },
           "name": "bool",
           "id": 9,
           "options": [],
@@ -1575,7 +2301,18 @@
             154,
             48
           ],
-          "fieldType": "google.protobuf.StringValue",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              154,
+              12
+            ],
+            "end": [
+              154,
+              38
+            ],
+            "name": "google.protobuf.StringValue"
+          },
           "name": "str",
           "id": 10,
           "options": [],
@@ -1593,7 +2330,18 @@
             155,
             49
           ],
-          "fieldType": "google.protobuf.BytesValue",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              155,
+              12
+            ],
+            "end": [
+              155,
+              37
+            ],
+            "name": "google.protobuf.BytesValue"
+          },
           "name": "bytes",
           "id": 11,
           "options": [],
@@ -1625,7 +2373,18 @@
             160,
             26
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              160,
+              12
+            ],
+            "end": [
+              160,
+              17
+            ],
+            "name": "string"
+          },
           "name": "str",
           "id": 1,
           "options": [],
@@ -1657,7 +2416,18 @@
             164,
             36
           ],
-          "fieldType": "MsgWithRequired",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              164,
+              12
+            ],
+            "end": [
+              164,
+              26
+            ],
+            "name": "MsgWithRequired"
+          },
           "name": "subm",
           "id": 1,
           "options": [],
@@ -1676,7 +2446,18 @@
             45
           ],
           "keyType": "string",
-          "valueType": "MsgWithRequired",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              165,
+              15
+            ],
+            "end": [
+              165,
+              29
+            ],
+            "name": "MsgWithRequired"
+          },
           "name": "map_field",
           "id": 2
         },
@@ -1690,7 +2471,18 @@
             166,
             43
           ],
-          "fieldType": "MsgWithRequired",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              166,
+              12
+            ],
+            "end": [
+              166,
+              26
+            ],
+            "name": "MsgWithRequired"
+          },
           "name": "slice_field",
           "id": 3,
           "options": [],
@@ -1722,7 +2514,18 @@
             170,
             26
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              170,
+              12
+            ],
+            "end": [
+              170,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "byts",
           "id": 1,
           "options": [],
@@ -1754,7 +2557,18 @@
             174,
             47
           ],
-          "fieldType": "google.protobuf.StringValue",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              174,
+              12
+            ],
+            "end": [
+              174,
+              38
+            ],
+            "name": "google.protobuf.StringValue"
+          },
           "name": "str",
           "id": 1,
           "options": [],
@@ -1786,7 +2600,18 @@
             178,
             38
           ],
-          "fieldType": "MsgWithRequired",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              178,
+              12
+            ],
+            "end": [
+              178,
+              26
+            ],
+            "name": "MsgWithRequired"
+          },
           "name": "extm",
           "id": 125,
           "options": [],

--- a/testdata/golang-jsonpb-test3.ast.json
+++ b/testdata/golang-jsonpb-test3.ast.json
@@ -82,7 +82,18 @@
             37,
             17
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              37,
+              3
+            ],
+            "end": [
+              37,
+              8
+            ],
+            "name": "double"
+          },
           "name": "dub",
           "id": 1,
           "options": [],
@@ -114,7 +125,18 @@
             41,
             29
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              41,
+              12
+            ],
+            "end": [
+              41,
+              17
+            ],
+            "name": "string"
+          },
           "name": "slices",
           "id": 1,
           "options": [],
@@ -147,7 +169,18 @@
             33
           ],
           "keyType": "string",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              45,
+              14
+            ],
+            "end": [
+              45,
+              19
+            ],
+            "name": "string"
+          },
           "name": "stringy",
           "id": 1
         }
@@ -175,7 +208,18 @@
             49,
             21
           ],
-          "fieldType": "Simple3",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              49,
+              3
+            ],
+            "end": [
+              49,
+              9
+            ],
+            "name": "Simple3"
+          },
           "name": "simple",
           "id": 1,
           "options": [],
@@ -261,7 +305,18 @@
             30
           ],
           "keyType": "int64",
-          "valueType": "int32",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              59,
+              14
+            ],
+            "end": [
+              59,
+              18
+            ],
+            "name": "int32"
+          },
           "name": "nummy",
           "id": 1
         },
@@ -276,7 +331,18 @@
             32
           ],
           "keyType": "string",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              60,
+              15
+            ],
+            "end": [
+              60,
+              20
+            ],
+            "name": "string"
+          },
           "name": "strry",
           "id": 2
         },
@@ -291,7 +357,18 @@
             32
           ],
           "keyType": "int32",
-          "valueType": "Simple3",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              61,
+              14
+            ],
+            "end": [
+              61,
+              20
+            ],
+            "name": "Simple3"
+          },
           "name": "objjy",
           "id": 3
         },
@@ -306,7 +383,18 @@
             31
           ],
           "keyType": "int64",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              62,
+              14
+            ],
+            "end": [
+              62,
+              19
+            ],
+            "name": "string"
+          },
           "name": "buggy",
           "id": 4
         },
@@ -321,7 +409,18 @@
             28
           ],
           "keyType": "bool",
-          "valueType": "bool",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              63,
+              13
+            ],
+            "end": [
+              63,
+              16
+            ],
+            "name": "bool"
+          },
           "name": "booly",
           "id": 5
         },
@@ -336,7 +435,18 @@
             33
           ],
           "keyType": "string",
-          "valueType": "Numeral",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              64,
+              15
+            ],
+            "end": [
+              64,
+              21
+            ],
+            "name": "Numeral"
+          },
           "name": "enumy",
           "id": 6
         },
@@ -351,7 +461,18 @@
             32
           ],
           "keyType": "int32",
-          "valueType": "bool",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              65,
+              14
+            ],
+            "end": [
+              65,
+              17
+            ],
+            "name": "bool"
+          },
           "name": "s32booly",
           "id": 7
         },
@@ -366,7 +487,18 @@
             32
           ],
           "keyType": "int64",
-          "valueType": "bool",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              66,
+              14
+            ],
+            "end": [
+              66,
+              17
+            ],
+            "name": "bool"
+          },
           "name": "s64booly",
           "id": 8
         },
@@ -381,7 +513,18 @@
             33
           ],
           "keyType": "uint32",
-          "valueType": "bool",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              67,
+              15
+            ],
+            "end": [
+              67,
+              18
+            ],
+            "name": "bool"
+          },
           "name": "u32booly",
           "id": 9
         },
@@ -396,7 +539,18 @@
             34
           ],
           "keyType": "uint64",
-          "valueType": "bool",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              68,
+              15
+            ],
+            "end": [
+              68,
+              18
+            ],
+            "name": "bool"
+          },
           "name": "u64booly",
           "id": 10
         }

--- a/testdata/golang-proto2-test.ast.json
+++ b/testdata/golang-proto2-test.ast.json
@@ -111,7 +111,18 @@
             40,
             23
           ],
-          "fieldType": "FOO",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              40,
+              12
+            ],
+            "end": [
+              40,
+              14
+            ],
+            "name": "FOO"
+          },
           "name": "foo",
           "id": 1,
           "options": [],
@@ -143,7 +154,18 @@
             44,
             28
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              44,
+              12
+            ],
+            "end": [
+              44,
+              17
+            ],
+            "name": "string"
+          },
           "name": "Label",
           "id": 1,
           "options": [],
@@ -161,7 +183,18 @@
             45,
             27
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              45,
+              12
+            ],
+            "end": [
+              45,
+              17
+            ],
+            "name": "string"
+          },
           "name": "Type",
           "id": 2,
           "options": [],
@@ -376,7 +409,18 @@
             75,
             25
           ],
-          "fieldType": "KIND",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              75,
+              12
+            ],
+            "end": [
+              75,
+              15
+            ],
+            "name": "KIND"
+          },
           "name": "Kind",
           "id": 1,
           "options": [],
@@ -394,7 +438,18 @@
             76,
             28
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              76,
+              12
+            ],
+            "end": [
+              76,
+              17
+            ],
+            "name": "string"
+          },
           "name": "Table",
           "id": 2,
           "options": [],
@@ -412,7 +467,18 @@
             77,
             27
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              77,
+              12
+            ],
+            "end": [
+              77,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "Param",
           "id": 3,
           "options": [],
@@ -430,7 +496,18 @@
             80,
             41
           ],
-          "fieldType": "GoTestField",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              80,
+              12
+            ],
+            "end": [
+              80,
+              22
+            ],
+            "name": "GoTestField"
+          },
           "name": "RequiredField",
           "id": 4,
           "options": [],
@@ -448,7 +525,18 @@
             81,
             41
           ],
-          "fieldType": "GoTestField",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              81,
+              12
+            ],
+            "end": [
+              81,
+              22
+            ],
+            "name": "GoTestField"
+          },
           "name": "RepeatedField",
           "id": 5,
           "options": [],
@@ -466,7 +554,18 @@
             82,
             41
           ],
-          "fieldType": "GoTestField",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              82,
+              12
+            ],
+            "end": [
+              82,
+              22
+            ],
+            "name": "GoTestField"
+          },
           "name": "OptionalField",
           "id": 6,
           "options": [],
@@ -484,7 +583,18 @@
             85,
             37
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              85,
+              12
+            ],
+            "end": [
+              85,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "F_Bool_required",
           "id": 10,
           "options": [],
@@ -502,7 +612,18 @@
             86,
             39
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              86,
+              12
+            ],
+            "end": [
+              86,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "F_Int32_required",
           "id": 11,
           "options": [],
@@ -520,7 +641,18 @@
             87,
             39
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              87,
+              12
+            ],
+            "end": [
+              87,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "F_Int64_required",
           "id": 12,
           "options": [],
@@ -538,7 +670,18 @@
             88,
             43
           ],
-          "fieldType": "fixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              88,
+              12
+            ],
+            "end": [
+              88,
+              18
+            ],
+            "name": "fixed32"
+          },
           "name": "F_Fixed32_required",
           "id": 13,
           "options": [],
@@ -556,7 +699,18 @@
             89,
             43
           ],
-          "fieldType": "fixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              89,
+              12
+            ],
+            "end": [
+              89,
+              18
+            ],
+            "name": "fixed64"
+          },
           "name": "F_Fixed64_required",
           "id": 14,
           "options": [],
@@ -574,7 +728,18 @@
             90,
             41
           ],
-          "fieldType": "uint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              90,
+              12
+            ],
+            "end": [
+              90,
+              17
+            ],
+            "name": "uint32"
+          },
           "name": "F_Uint32_required",
           "id": 15,
           "options": [],
@@ -592,7 +757,18 @@
             91,
             41
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              91,
+              12
+            ],
+            "end": [
+              91,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "F_Uint64_required",
           "id": 16,
           "options": [],
@@ -610,7 +786,18 @@
             92,
             39
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              92,
+              12
+            ],
+            "end": [
+              92,
+              16
+            ],
+            "name": "float"
+          },
           "name": "F_Float_required",
           "id": 17,
           "options": [],
@@ -628,7 +815,18 @@
             93,
             41
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              93,
+              12
+            ],
+            "end": [
+              93,
+              17
+            ],
+            "name": "double"
+          },
           "name": "F_Double_required",
           "id": 18,
           "options": [],
@@ -646,7 +844,18 @@
             94,
             41
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              94,
+              12
+            ],
+            "end": [
+              94,
+              17
+            ],
+            "name": "string"
+          },
           "name": "F_String_required",
           "id": 19,
           "options": [],
@@ -664,7 +873,18 @@
             95,
             40
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              95,
+              12
+            ],
+            "end": [
+              95,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "F_Bytes_required",
           "id": 101,
           "options": [],
@@ -682,7 +902,18 @@
             96,
             42
           ],
-          "fieldType": "sint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              96,
+              12
+            ],
+            "end": [
+              96,
+              17
+            ],
+            "name": "sint32"
+          },
           "name": "F_Sint32_required",
           "id": 102,
           "options": [],
@@ -700,7 +931,18 @@
             97,
             42
           ],
-          "fieldType": "sint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              97,
+              12
+            ],
+            "end": [
+              97,
+              17
+            ],
+            "name": "sint64"
+          },
           "name": "F_Sint64_required",
           "id": 103,
           "options": [],
@@ -718,7 +960,18 @@
             98,
             46
           ],
-          "fieldType": "sfixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              98,
+              12
+            ],
+            "end": [
+              98,
+              19
+            ],
+            "name": "sfixed32"
+          },
           "name": "F_Sfixed32_required",
           "id": 104,
           "options": [],
@@ -736,7 +989,18 @@
             99,
             46
           ],
-          "fieldType": "sfixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              99,
+              12
+            ],
+            "end": [
+              99,
+              19
+            ],
+            "name": "sfixed64"
+          },
           "name": "F_Sfixed64_required",
           "id": 105,
           "options": [],
@@ -754,7 +1018,18 @@
             102,
             37
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              102,
+              12
+            ],
+            "end": [
+              102,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "F_Bool_repeated",
           "id": 20,
           "options": [],
@@ -772,7 +1047,18 @@
             103,
             39
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              103,
+              12
+            ],
+            "end": [
+              103,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "F_Int32_repeated",
           "id": 21,
           "options": [],
@@ -790,7 +1076,18 @@
             104,
             39
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              104,
+              12
+            ],
+            "end": [
+              104,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "F_Int64_repeated",
           "id": 22,
           "options": [],
@@ -808,7 +1105,18 @@
             105,
             43
           ],
-          "fieldType": "fixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              105,
+              12
+            ],
+            "end": [
+              105,
+              18
+            ],
+            "name": "fixed32"
+          },
           "name": "F_Fixed32_repeated",
           "id": 23,
           "options": [],
@@ -826,7 +1134,18 @@
             106,
             43
           ],
-          "fieldType": "fixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              106,
+              12
+            ],
+            "end": [
+              106,
+              18
+            ],
+            "name": "fixed64"
+          },
           "name": "F_Fixed64_repeated",
           "id": 24,
           "options": [],
@@ -844,7 +1163,18 @@
             107,
             41
           ],
-          "fieldType": "uint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              107,
+              12
+            ],
+            "end": [
+              107,
+              17
+            ],
+            "name": "uint32"
+          },
           "name": "F_Uint32_repeated",
           "id": 25,
           "options": [],
@@ -862,7 +1192,18 @@
             108,
             41
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              108,
+              12
+            ],
+            "end": [
+              108,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "F_Uint64_repeated",
           "id": 26,
           "options": [],
@@ -880,7 +1221,18 @@
             109,
             39
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              109,
+              12
+            ],
+            "end": [
+              109,
+              16
+            ],
+            "name": "float"
+          },
           "name": "F_Float_repeated",
           "id": 27,
           "options": [],
@@ -898,7 +1250,18 @@
             110,
             41
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              110,
+              12
+            ],
+            "end": [
+              110,
+              17
+            ],
+            "name": "double"
+          },
           "name": "F_Double_repeated",
           "id": 28,
           "options": [],
@@ -916,7 +1279,18 @@
             111,
             41
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              111,
+              12
+            ],
+            "end": [
+              111,
+              17
+            ],
+            "name": "string"
+          },
           "name": "F_String_repeated",
           "id": 29,
           "options": [],
@@ -934,7 +1308,18 @@
             112,
             40
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              112,
+              12
+            ],
+            "end": [
+              112,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "F_Bytes_repeated",
           "id": 201,
           "options": [],
@@ -952,7 +1337,18 @@
             113,
             42
           ],
-          "fieldType": "sint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              113,
+              12
+            ],
+            "end": [
+              113,
+              17
+            ],
+            "name": "sint32"
+          },
           "name": "F_Sint32_repeated",
           "id": 202,
           "options": [],
@@ -970,7 +1366,18 @@
             114,
             42
           ],
-          "fieldType": "sint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              114,
+              12
+            ],
+            "end": [
+              114,
+              17
+            ],
+            "name": "sint64"
+          },
           "name": "F_Sint64_repeated",
           "id": 203,
           "options": [],
@@ -988,7 +1395,18 @@
             115,
             46
           ],
-          "fieldType": "sfixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              115,
+              12
+            ],
+            "end": [
+              115,
+              19
+            ],
+            "name": "sfixed32"
+          },
           "name": "F_Sfixed32_repeated",
           "id": 204,
           "options": [],
@@ -1006,7 +1424,18 @@
             116,
             46
           ],
-          "fieldType": "sfixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              116,
+              12
+            ],
+            "end": [
+              116,
+              19
+            ],
+            "name": "sfixed64"
+          },
           "name": "F_Sfixed64_repeated",
           "id": 205,
           "options": [],
@@ -1024,7 +1453,18 @@
             119,
             37
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              119,
+              12
+            ],
+            "end": [
+              119,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "F_Bool_optional",
           "id": 30,
           "options": [],
@@ -1042,7 +1482,18 @@
             120,
             39
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              120,
+              12
+            ],
+            "end": [
+              120,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "F_Int32_optional",
           "id": 31,
           "options": [],
@@ -1060,7 +1511,18 @@
             121,
             39
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              121,
+              12
+            ],
+            "end": [
+              121,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "F_Int64_optional",
           "id": 32,
           "options": [],
@@ -1078,7 +1540,18 @@
             122,
             43
           ],
-          "fieldType": "fixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              122,
+              12
+            ],
+            "end": [
+              122,
+              18
+            ],
+            "name": "fixed32"
+          },
           "name": "F_Fixed32_optional",
           "id": 33,
           "options": [],
@@ -1096,7 +1569,18 @@
             123,
             43
           ],
-          "fieldType": "fixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              123,
+              12
+            ],
+            "end": [
+              123,
+              18
+            ],
+            "name": "fixed64"
+          },
           "name": "F_Fixed64_optional",
           "id": 34,
           "options": [],
@@ -1114,7 +1598,18 @@
             124,
             41
           ],
-          "fieldType": "uint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              124,
+              12
+            ],
+            "end": [
+              124,
+              17
+            ],
+            "name": "uint32"
+          },
           "name": "F_Uint32_optional",
           "id": 35,
           "options": [],
@@ -1132,7 +1627,18 @@
             125,
             41
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              125,
+              12
+            ],
+            "end": [
+              125,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "F_Uint64_optional",
           "id": 36,
           "options": [],
@@ -1150,7 +1656,18 @@
             126,
             39
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              126,
+              12
+            ],
+            "end": [
+              126,
+              16
+            ],
+            "name": "float"
+          },
           "name": "F_Float_optional",
           "id": 37,
           "options": [],
@@ -1168,7 +1685,18 @@
             127,
             41
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              127,
+              12
+            ],
+            "end": [
+              127,
+              17
+            ],
+            "name": "double"
+          },
           "name": "F_Double_optional",
           "id": 38,
           "options": [],
@@ -1186,7 +1714,18 @@
             128,
             41
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              128,
+              12
+            ],
+            "end": [
+              128,
+              17
+            ],
+            "name": "string"
+          },
           "name": "F_String_optional",
           "id": 39,
           "options": [],
@@ -1204,7 +1743,18 @@
             129,
             40
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              129,
+              12
+            ],
+            "end": [
+              129,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "F_Bytes_optional",
           "id": 301,
           "options": [],
@@ -1222,7 +1772,18 @@
             130,
             42
           ],
-          "fieldType": "sint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              130,
+              12
+            ],
+            "end": [
+              130,
+              17
+            ],
+            "name": "sint32"
+          },
           "name": "F_Sint32_optional",
           "id": 302,
           "options": [],
@@ -1240,7 +1801,18 @@
             131,
             42
           ],
-          "fieldType": "sint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              131,
+              12
+            ],
+            "end": [
+              131,
+              17
+            ],
+            "name": "sint64"
+          },
           "name": "F_Sint64_optional",
           "id": 303,
           "options": [],
@@ -1258,7 +1830,18 @@
             132,
             46
           ],
-          "fieldType": "sfixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              132,
+              12
+            ],
+            "end": [
+              132,
+              19
+            ],
+            "name": "sfixed32"
+          },
           "name": "F_Sfixed32_optional",
           "id": 304,
           "options": [],
@@ -1276,7 +1859,18 @@
             133,
             46
           ],
-          "fieldType": "sfixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              133,
+              12
+            ],
+            "end": [
+              133,
+              19
+            ],
+            "name": "sfixed64"
+          },
           "name": "F_Sfixed64_optional",
           "id": 305,
           "options": [],
@@ -1294,7 +1888,18 @@
             136,
             53
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              136,
+              12
+            ],
+            "end": [
+              136,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "F_Bool_defaulted",
           "id": 40,
           "options": [
@@ -1342,7 +1947,18 @@
             137,
             53
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              137,
+              12
+            ],
+            "end": [
+              137,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "F_Int32_defaulted",
           "id": 41,
           "options": [
@@ -1390,7 +2006,18 @@
             138,
             53
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              138,
+              12
+            ],
+            "end": [
+              138,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "F_Int64_defaulted",
           "id": 42,
           "options": [
@@ -1438,7 +2065,18 @@
             139,
             58
           ],
-          "fieldType": "fixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              139,
+              12
+            ],
+            "end": [
+              139,
+              18
+            ],
+            "name": "fixed32"
+          },
           "name": "F_Fixed32_defaulted",
           "id": 43,
           "options": [
@@ -1486,7 +2124,18 @@
             140,
             58
           ],
-          "fieldType": "fixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              140,
+              12
+            ],
+            "end": [
+              140,
+              18
+            ],
+            "name": "fixed64"
+          },
           "name": "F_Fixed64_defaulted",
           "id": 44,
           "options": [
@@ -1534,7 +2183,18 @@
             141,
             57
           ],
-          "fieldType": "uint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              141,
+              12
+            ],
+            "end": [
+              141,
+              17
+            ],
+            "name": "uint32"
+          },
           "name": "F_Uint32_defaulted",
           "id": 45,
           "options": [
@@ -1582,7 +2242,18 @@
             142,
             57
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              142,
+              12
+            ],
+            "end": [
+              142,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "F_Uint64_defaulted",
           "id": 46,
           "options": [
@@ -1630,7 +2301,18 @@
             143,
             58
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              143,
+              12
+            ],
+            "end": [
+              143,
+              16
+            ],
+            "name": "float"
+          },
           "name": "F_Float_defaulted",
           "id": 47,
           "options": [
@@ -1678,7 +2360,18 @@
             144,
             60
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              144,
+              12
+            ],
+            "end": [
+              144,
+              17
+            ],
+            "name": "double"
+          },
           "name": "F_Double_defaulted",
           "id": 48,
           "options": [
@@ -1726,7 +2419,18 @@
             145,
             74
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              145,
+              12
+            ],
+            "end": [
+              145,
+              17
+            ],
+            "name": "string"
+          },
           "name": "F_String_defaulted",
           "id": 49,
           "options": [
@@ -1774,7 +2478,18 @@
             146,
             61
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              146,
+              12
+            ],
+            "end": [
+              146,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "F_Bytes_defaulted",
           "id": 401,
           "options": [
@@ -1822,7 +2537,18 @@
             147,
             59
           ],
-          "fieldType": "sint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              147,
+              12
+            ],
+            "end": [
+              147,
+              17
+            ],
+            "name": "sint32"
+          },
           "name": "F_Sint32_defaulted",
           "id": 402,
           "options": [
@@ -1870,7 +2596,18 @@
             148,
             59
           ],
-          "fieldType": "sint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              148,
+              12
+            ],
+            "end": [
+              148,
+              17
+            ],
+            "name": "sint64"
+          },
           "name": "F_Sint64_defaulted",
           "id": 403,
           "options": [
@@ -1918,7 +2655,18 @@
             149,
             63
           ],
-          "fieldType": "sfixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              149,
+              12
+            ],
+            "end": [
+              149,
+              19
+            ],
+            "name": "sfixed32"
+          },
           "name": "F_Sfixed32_defaulted",
           "id": 404,
           "options": [
@@ -1966,7 +2714,18 @@
             150,
             63
           ],
-          "fieldType": "sfixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              150,
+              12
+            ],
+            "end": [
+              150,
+              19
+            ],
+            "name": "sfixed64"
+          },
           "name": "F_Sfixed64_defaulted",
           "id": 405,
           "options": [
@@ -2014,7 +2773,18 @@
             153,
             58
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              153,
+              12
+            ],
+            "end": [
+              153,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "F_Bool_repeated_packed",
           "id": 50,
           "options": [
@@ -2062,7 +2832,18 @@
             154,
             60
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              154,
+              12
+            ],
+            "end": [
+              154,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "F_Int32_repeated_packed",
           "id": 51,
           "options": [
@@ -2110,7 +2891,18 @@
             155,
             60
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              155,
+              12
+            ],
+            "end": [
+              155,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "F_Int64_repeated_packed",
           "id": 52,
           "options": [
@@ -2158,7 +2950,18 @@
             156,
             64
           ],
-          "fieldType": "fixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              156,
+              12
+            ],
+            "end": [
+              156,
+              18
+            ],
+            "name": "fixed32"
+          },
           "name": "F_Fixed32_repeated_packed",
           "id": 53,
           "options": [
@@ -2206,7 +3009,18 @@
             157,
             64
           ],
-          "fieldType": "fixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              157,
+              12
+            ],
+            "end": [
+              157,
+              18
+            ],
+            "name": "fixed64"
+          },
           "name": "F_Fixed64_repeated_packed",
           "id": 54,
           "options": [
@@ -2254,7 +3068,18 @@
             158,
             62
           ],
-          "fieldType": "uint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              158,
+              12
+            ],
+            "end": [
+              158,
+              17
+            ],
+            "name": "uint32"
+          },
           "name": "F_Uint32_repeated_packed",
           "id": 55,
           "options": [
@@ -2302,7 +3127,18 @@
             159,
             62
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              159,
+              12
+            ],
+            "end": [
+              159,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "F_Uint64_repeated_packed",
           "id": 56,
           "options": [
@@ -2350,7 +3186,18 @@
             160,
             60
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              160,
+              12
+            ],
+            "end": [
+              160,
+              16
+            ],
+            "name": "float"
+          },
           "name": "F_Float_repeated_packed",
           "id": 57,
           "options": [
@@ -2398,7 +3245,18 @@
             161,
             62
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              161,
+              12
+            ],
+            "end": [
+              161,
+              17
+            ],
+            "name": "double"
+          },
           "name": "F_Double_repeated_packed",
           "id": 58,
           "options": [
@@ -2446,7 +3304,18 @@
             162,
             63
           ],
-          "fieldType": "sint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              162,
+              12
+            ],
+            "end": [
+              162,
+              17
+            ],
+            "name": "sint32"
+          },
           "name": "F_Sint32_repeated_packed",
           "id": 502,
           "options": [
@@ -2494,7 +3363,18 @@
             163,
             63
           ],
-          "fieldType": "sint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              163,
+              12
+            ],
+            "end": [
+              163,
+              17
+            ],
+            "name": "sint64"
+          },
           "name": "F_Sint64_repeated_packed",
           "id": 503,
           "options": [
@@ -2542,7 +3422,18 @@
             164,
             67
           ],
-          "fieldType": "sfixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              164,
+              12
+            ],
+            "end": [
+              164,
+              19
+            ],
+            "name": "sfixed32"
+          },
           "name": "F_Sfixed32_repeated_packed",
           "id": 504,
           "options": [
@@ -2590,7 +3481,18 @@
             165,
             67
           ],
-          "fieldType": "sfixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              165,
+              12
+            ],
+            "end": [
+              165,
+              19
+            ],
+            "name": "sfixed64"
+          },
           "name": "F_Sfixed64_repeated_packed",
           "id": 505,
           "options": [
@@ -2654,7 +3556,18 @@
                 169,
                 39
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  169,
+                  14
+                ],
+                "end": [
+                  169,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "RequiredField",
               "id": 71,
               "options": [],
@@ -2690,7 +3603,18 @@
                 173,
                 39
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  173,
+                  14
+                ],
+                "end": [
+                  173,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "RequiredField",
               "id": 81,
               "options": [],
@@ -2726,7 +3650,18 @@
                 177,
                 39
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  177,
+                  14
+                ],
+                "end": [
+                  177,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "RequiredField",
               "id": 91,
               "options": [],
@@ -2776,7 +3711,18 @@
                 184,
                 29
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  184,
+                  14
+                ],
+                "end": [
+                  184,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "Field",
               "id": 2,
               "options": [],
@@ -2810,7 +3756,18 @@
             192,
             33
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              192,
+              12
+            ],
+            "end": [
+              192,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "skip_int32",
           "id": 11,
           "options": [],
@@ -2828,7 +3785,18 @@
             193,
             37
           ],
-          "fieldType": "fixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              193,
+              12
+            ],
+            "end": [
+              193,
+              18
+            ],
+            "name": "fixed32"
+          },
           "name": "skip_fixed32",
           "id": 12,
           "options": [],
@@ -2846,7 +3814,18 @@
             194,
             37
           ],
-          "fieldType": "fixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              194,
+              12
+            ],
+            "end": [
+              194,
+              18
+            ],
+            "name": "fixed64"
+          },
           "name": "skip_fixed64",
           "id": 13,
           "options": [],
@@ -2864,7 +3843,18 @@
             195,
             35
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              195,
+              12
+            ],
+            "end": [
+              195,
+              17
+            ],
+            "name": "string"
+          },
           "name": "skip_string",
           "id": 14,
           "options": [],
@@ -2898,7 +3888,18 @@
                 197,
                 36
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  197,
+                  14
+                ],
+                "end": [
+                  197,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "group_int32",
               "id": 16,
               "options": [],
@@ -2916,7 +3917,18 @@
                 198,
                 38
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  198,
+                  14
+                ],
+                "end": [
+                  198,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "group_string",
               "id": 17,
               "options": [],
@@ -2950,7 +3962,18 @@
             205,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              205,
+              12
+            ],
+            "end": [
+              205,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -2982,7 +4005,18 @@
             209,
             37
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              209,
+              12
+            ],
+            "end": [
+              209,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "b",
           "id": 1,
           "options": [
@@ -3044,7 +4078,18 @@
             214,
             41
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              214,
+              12
+            ],
+            "end": [
+              214,
+              17
+            ],
+            "name": "string"
+          },
           "name": "last_field",
           "id": 536870911,
           "options": [],
@@ -3088,7 +4133,18 @@
                 219,
                 29
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  219,
+                  14
+                ],
+                "end": [
+                  219,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "name",
               "id": 1,
               "options": [],
@@ -3108,7 +4164,18 @@
             221,
             29
           ],
-          "fieldType": "Nested",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              221,
+              12
+            ],
+            "end": [
+              221,
+              17
+            ],
+            "name": "Nested"
+          },
           "name": "nested",
           "id": 1,
           "options": [],
@@ -3126,7 +4193,18 @@
             223,
             25
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              223,
+              12
+            ],
+            "end": [
+              223,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "num",
           "id": 2,
           "options": [],
@@ -3170,7 +4248,18 @@
                 230,
                 29
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  230,
+                  14
+                ],
+                "end": [
+                  230,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "name",
               "id": 1,
               "options": [],
@@ -3188,7 +4277,18 @@
                 231,
                 35
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  231,
+                  14
+                ],
+                "end": [
+                  231,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "food_group",
               "id": 2,
               "options": [],
@@ -3208,7 +4308,18 @@
             233,
             29
           ],
-          "fieldType": "Nested",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              233,
+              12
+            ],
+            "end": [
+              233,
+              17
+            ],
+            "name": "Nested"
+          },
           "name": "nested",
           "id": 1,
           "options": [],
@@ -3226,7 +4337,18 @@
             236,
             25
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              236,
+              12
+            ],
+            "end": [
+              236,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "num",
           "id": 2,
           "options": [],
@@ -3258,7 +4380,18 @@
             242,
             27
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              242,
+              12
+            ],
+            "end": [
+              242,
+              17
+            ],
+            "name": "string"
+          },
           "name": "host",
           "id": 1,
           "options": [],
@@ -3276,7 +4409,18 @@
             243,
             41
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              243,
+              12
+            ],
+            "end": [
+              243,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "port",
           "id": 2,
           "options": [
@@ -3324,7 +4468,18 @@
             244,
             30
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              244,
+              12
+            ],
+            "end": [
+              244,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "connected",
           "id": 3,
           "options": [],
@@ -3356,7 +4511,18 @@
             248,
             25
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              248,
+              12
+            ],
+            "end": [
+              248,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "key",
           "id": 1,
           "options": [],
@@ -3374,7 +4540,18 @@
             249,
             27
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              249,
+              12
+            ],
+            "end": [
+              249,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "value",
           "id": 2,
           "options": [],
@@ -3392,7 +4569,18 @@
             250,
             28
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              250,
+              12
+            ],
+            "end": [
+              250,
+              16
+            ],
+            "name": "float"
+          },
           "name": "weight",
           "id": 3,
           "options": [],
@@ -3410,7 +4598,18 @@
             251,
             34
           ],
-          "fieldType": "InnerMessage",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              251,
+              12
+            ],
+            "end": [
+              251,
+              23
+            ],
+            "name": "InnerMessage"
+          },
           "name": "inner",
           "id": 4,
           "options": [],
@@ -3459,7 +4658,18 @@
             257,
             53
           ],
-          "fieldType": "InnerMessage",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              257,
+              12
+            ],
+            "end": [
+              257,
+              23
+            ],
+            "name": "InnerMessage"
+          },
           "name": "leo_finally_won_an_oscar",
           "id": 1,
           "options": [],
@@ -3491,7 +4701,18 @@
             261,
             27
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              261,
+              12
+            ],
+            "end": [
+              261,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "count",
           "id": 1,
           "options": [],
@@ -3509,7 +4730,18 @@
             262,
             27
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              262,
+              12
+            ],
+            "end": [
+              262,
+              17
+            ],
+            "name": "string"
+          },
           "name": "name",
           "id": 2,
           "options": [],
@@ -3527,7 +4759,18 @@
             263,
             28
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              263,
+              12
+            ],
+            "end": [
+              263,
+              17
+            ],
+            "name": "string"
+          },
           "name": "quote",
           "id": 3,
           "options": [],
@@ -3545,7 +4788,18 @@
             264,
             26
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              264,
+              12
+            ],
+            "end": [
+              264,
+              17
+            ],
+            "name": "string"
+          },
           "name": "pet",
           "id": 4,
           "options": [],
@@ -3563,7 +4817,18 @@
             265,
             34
           ],
-          "fieldType": "InnerMessage",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              265,
+              12
+            ],
+            "end": [
+              265,
+              23
+            ],
+            "name": "InnerMessage"
+          },
           "name": "inner",
           "id": 5,
           "options": [],
@@ -3581,7 +4846,18 @@
             266,
             35
           ],
-          "fieldType": "OtherMessage",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              266,
+              12
+            ],
+            "end": [
+              266,
+              23
+            ],
+            "name": "OtherMessage"
+          },
           "name": "others",
           "id": 6,
           "options": [],
@@ -3599,7 +4875,18 @@
             267,
             55
           ],
-          "fieldType": "RequiredInnerMessage",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              267,
+              12
+            ],
+            "end": [
+              267,
+              31
+            ],
+            "name": "RequiredInnerMessage"
+          },
           "name": "we_must_go_deeper",
           "id": 13,
           "options": [],
@@ -3617,7 +4904,18 @@
             268,
             39
           ],
-          "fieldType": "InnerMessage",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              268,
+              12
+            ],
+            "end": [
+              268,
+              23
+            ],
+            "name": "InnerMessage"
+          },
           "name": "rep_inner",
           "id": 12,
           "options": [],
@@ -3688,7 +4986,18 @@
             275,
             30
           ],
-          "fieldType": "Color",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              275,
+              12
+            ],
+            "end": [
+              275,
+              16
+            ],
+            "name": "Color"
+          },
           "name": "bikeshed",
           "id": 7,
           "options": [],
@@ -3722,7 +5031,18 @@
                 278,
                 35
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  278,
+                  14
+                ],
+                "end": [
+                  278,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "group_field",
               "id": 9,
               "options": [],
@@ -3742,7 +5062,18 @@
             282,
             32
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              282,
+              12
+            ],
+            "end": [
+              282,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "rep_bytes",
           "id": 10,
           "options": [],
@@ -3760,7 +5091,18 @@
             284,
             32
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              284,
+              12
+            ],
+            "end": [
+              284,
+              17
+            ],
+            "name": "double"
+          },
           "name": "bigfloat",
           "id": 11,
           "options": [],
@@ -3821,7 +5163,18 @@
                 291,
                 28
               ],
-              "fieldType": "Ext",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  291,
+                  14
+                ],
+                "end": [
+                  291,
+                  16
+                ],
+                "name": "Ext"
+              },
               "name": "more",
               "id": 103,
               "options": [],
@@ -3839,7 +5192,18 @@
                 292,
                 31
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  292,
+                  14
+                ],
+                "end": [
+                  292,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "text",
               "id": 104,
               "options": [],
@@ -3857,7 +5221,18 @@
                 293,
                 32
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  293,
+                  14
+                ],
+                "end": [
+                  293,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "number",
               "id": 105,
               "options": [],
@@ -3877,7 +5252,18 @@
             296,
             27
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              296,
+              12
+            ],
+            "end": [
+              296,
+              17
+            ],
+            "name": "string"
+          },
           "name": "data",
           "id": 1,
           "options": [],
@@ -3896,7 +5282,18 @@
             34
           ],
           "keyType": "int32",
-          "valueType": "int32",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              297,
+              14
+            ],
+            "end": [
+              297,
+              18
+            ],
+            "name": "int32"
+          },
           "name": "map_field",
           "id": 2
         }
@@ -3924,7 +5321,18 @@
             301,
             33
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              301,
+              12
+            ],
+            "end": [
+              301,
+              17
+            ],
+            "name": "string"
+          },
           "name": "greeting",
           "id": 106,
           "options": [],
@@ -3956,7 +5364,18 @@
             306,
             27
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              306,
+              12
+            ],
+            "end": [
+              306,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "first",
           "id": 1,
           "options": [],
@@ -3974,7 +5393,18 @@
             307,
             28
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              307,
+              12
+            ],
+            "end": [
+              307,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "second",
           "id": 2,
           "options": [],
@@ -3992,7 +5422,18 @@
             308,
             27
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              308,
+              12
+            ],
+            "end": [
+              308,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "third",
           "id": 3,
           "options": [],
@@ -4024,7 +5465,18 @@
             312,
             42
           ],
-          "fieldType": "ComplexExtension",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              312,
+              12
+            ],
+            "end": [
+              312,
+              27
+            ],
+            "name": "ComplexExtension"
+          },
           "name": "complex",
           "id": 200,
           "options": [],
@@ -4042,7 +5494,18 @@
             313,
             44
           ],
-          "fieldType": "ComplexExtension",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              313,
+              12
+            ],
+            "end": [
+              313,
+              27
+            ],
+            "name": "ComplexExtension"
+          },
           "name": "r_complex",
           "id": 201,
           "options": [],
@@ -4158,7 +5621,18 @@
             326,
             42
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              326,
+              12
+            ],
+            "end": [
+              326,
+              17
+            ],
+            "name": "double"
+          },
           "name": "no_default_double",
           "id": 101,
           "options": [],
@@ -4176,7 +5650,18 @@
             327,
             40
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              327,
+              12
+            ],
+            "end": [
+              327,
+              16
+            ],
+            "name": "float"
+          },
           "name": "no_default_float",
           "id": 102,
           "options": [],
@@ -4194,7 +5679,18 @@
             328,
             40
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              328,
+              12
+            ],
+            "end": [
+              328,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "no_default_int32",
           "id": 103,
           "options": [],
@@ -4212,7 +5708,18 @@
             329,
             40
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              329,
+              12
+            ],
+            "end": [
+              329,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "no_default_int64",
           "id": 104,
           "options": [],
@@ -4230,7 +5737,18 @@
             330,
             42
           ],
-          "fieldType": "uint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              330,
+              12
+            ],
+            "end": [
+              330,
+              17
+            ],
+            "name": "uint32"
+          },
           "name": "no_default_uint32",
           "id": 105,
           "options": [],
@@ -4248,7 +5766,18 @@
             331,
             42
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              331,
+              12
+            ],
+            "end": [
+              331,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "no_default_uint64",
           "id": 106,
           "options": [],
@@ -4266,7 +5795,18 @@
             332,
             42
           ],
-          "fieldType": "sint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              332,
+              12
+            ],
+            "end": [
+              332,
+              17
+            ],
+            "name": "sint32"
+          },
           "name": "no_default_sint32",
           "id": 107,
           "options": [],
@@ -4284,7 +5824,18 @@
             333,
             42
           ],
-          "fieldType": "sint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              333,
+              12
+            ],
+            "end": [
+              333,
+              17
+            ],
+            "name": "sint64"
+          },
           "name": "no_default_sint64",
           "id": 108,
           "options": [],
@@ -4302,7 +5853,18 @@
             334,
             44
           ],
-          "fieldType": "fixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              334,
+              12
+            ],
+            "end": [
+              334,
+              18
+            ],
+            "name": "fixed32"
+          },
           "name": "no_default_fixed32",
           "id": 109,
           "options": [],
@@ -4320,7 +5882,18 @@
             335,
             44
           ],
-          "fieldType": "fixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              335,
+              12
+            ],
+            "end": [
+              335,
+              18
+            ],
+            "name": "fixed64"
+          },
           "name": "no_default_fixed64",
           "id": 110,
           "options": [],
@@ -4338,7 +5911,18 @@
             336,
             46
           ],
-          "fieldType": "sfixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              336,
+              12
+            ],
+            "end": [
+              336,
+              19
+            ],
+            "name": "sfixed32"
+          },
           "name": "no_default_sfixed32",
           "id": 111,
           "options": [],
@@ -4356,7 +5940,18 @@
             337,
             46
           ],
-          "fieldType": "sfixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              337,
+              12
+            ],
+            "end": [
+              337,
+              19
+            ],
+            "name": "sfixed64"
+          },
           "name": "no_default_sfixed64",
           "id": 112,
           "options": [],
@@ -4374,7 +5969,18 @@
             338,
             38
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              338,
+              12
+            ],
+            "end": [
+              338,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "no_default_bool",
           "id": 113,
           "options": [],
@@ -4392,7 +5998,18 @@
             339,
             42
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              339,
+              12
+            ],
+            "end": [
+              339,
+              17
+            ],
+            "name": "string"
+          },
           "name": "no_default_string",
           "id": 114,
           "options": [],
@@ -4410,7 +6027,18 @@
             340,
             40
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              340,
+              12
+            ],
+            "end": [
+              340,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "no_default_bytes",
           "id": 115,
           "options": [],
@@ -4428,7 +6056,18 @@
             341,
             62
           ],
-          "fieldType": "DefaultsMessage.DefaultsEnum",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              341,
+              12
+            ],
+            "end": [
+              341,
+              39
+            ],
+            "name": "DefaultsMessage.DefaultsEnum"
+          },
           "name": "no_default_enum",
           "id": 116,
           "options": [],
@@ -4446,7 +6085,18 @@
             343,
             58
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              343,
+              12
+            ],
+            "end": [
+              343,
+              17
+            ],
+            "name": "double"
+          },
           "name": "default_double",
           "id": 201,
           "options": [
@@ -4494,7 +6144,18 @@
             344,
             54
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              344,
+              12
+            ],
+            "end": [
+              344,
+              16
+            ],
+            "name": "float"
+          },
           "name": "default_float",
           "id": 202,
           "options": [
@@ -4542,7 +6203,18 @@
             345,
             52
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              345,
+              12
+            ],
+            "end": [
+              345,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "default_int32",
           "id": 203,
           "options": [
@@ -4590,7 +6262,18 @@
             346,
             52
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              346,
+              12
+            ],
+            "end": [
+              346,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "default_int64",
           "id": 204,
           "options": [
@@ -4638,7 +6321,18 @@
             347,
             54
           ],
-          "fieldType": "uint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              347,
+              12
+            ],
+            "end": [
+              347,
+              17
+            ],
+            "name": "uint32"
+          },
           "name": "default_uint32",
           "id": 205,
           "options": [
@@ -4686,7 +6380,18 @@
             348,
             54
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              348,
+              12
+            ],
+            "end": [
+              348,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "default_uint64",
           "id": 206,
           "options": [
@@ -4734,7 +6439,18 @@
             349,
             54
           ],
-          "fieldType": "sint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              349,
+              12
+            ],
+            "end": [
+              349,
+              17
+            ],
+            "name": "sint32"
+          },
           "name": "default_sint32",
           "id": 207,
           "options": [
@@ -4782,7 +6498,18 @@
             350,
             54
           ],
-          "fieldType": "sint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              350,
+              12
+            ],
+            "end": [
+              350,
+              17
+            ],
+            "name": "sint64"
+          },
           "name": "default_sint64",
           "id": 208,
           "options": [
@@ -4830,7 +6557,18 @@
             351,
             56
           ],
-          "fieldType": "fixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              351,
+              12
+            ],
+            "end": [
+              351,
+              18
+            ],
+            "name": "fixed32"
+          },
           "name": "default_fixed32",
           "id": 209,
           "options": [
@@ -4878,7 +6616,18 @@
             352,
             56
           ],
-          "fieldType": "fixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              352,
+              12
+            ],
+            "end": [
+              352,
+              18
+            ],
+            "name": "fixed64"
+          },
           "name": "default_fixed64",
           "id": 210,
           "options": [
@@ -4926,7 +6675,18 @@
             353,
             58
           ],
-          "fieldType": "sfixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              353,
+              12
+            ],
+            "end": [
+              353,
+              19
+            ],
+            "name": "sfixed32"
+          },
           "name": "default_sfixed32",
           "id": 211,
           "options": [
@@ -4974,7 +6734,18 @@
             354,
             58
           ],
-          "fieldType": "sfixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              354,
+              12
+            ],
+            "end": [
+              354,
+              19
+            ],
+            "name": "sfixed64"
+          },
           "name": "default_sfixed64",
           "id": 212,
           "options": [
@@ -5022,7 +6793,18 @@
             355,
             52
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              355,
+              12
+            ],
+            "end": [
+              355,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "default_bool",
           "id": 213,
           "options": [
@@ -5070,7 +6852,18 @@
             356,
             75
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              356,
+              12
+            ],
+            "end": [
+              356,
+              17
+            ],
+            "name": "string"
+          },
           "name": "default_string",
           "id": 214,
           "options": [
@@ -5118,7 +6911,18 @@
             357,
             64
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              357,
+              12
+            ],
+            "end": [
+              357,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "default_bytes",
           "id": 215,
           "options": [
@@ -5166,7 +6970,18 @@
             358,
             75
           ],
-          "fieldType": "DefaultsMessage.DefaultsEnum",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              358,
+              12
+            ],
+            "end": [
+              358,
+              39
+            ],
+            "name": "DefaultsMessage.DefaultsEnum"
+          },
           "name": "default_enum",
           "id": 216,
           "options": [
@@ -5257,7 +7072,18 @@
                 366,
                 29
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  366,
+                  14
+                ],
+                "end": [
+                  366,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "name",
               "id": 2,
               "options": [],
@@ -5275,7 +7101,18 @@
                 367,
                 29
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  367,
+                  14
+                ],
+                "end": [
+                  367,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "count",
               "id": 3,
               "options": [],
@@ -5309,7 +7146,18 @@
             372,
             35
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              372,
+              12
+            ],
+            "end": [
+              372,
+              17
+            ],
+            "name": "string"
+          },
           "name": "string_field",
           "id": 1,
           "options": [],
@@ -5327,7 +7175,18 @@
             373,
             33
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              373,
+              12
+            ],
+            "end": [
+              373,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "bytes_field",
           "id": 2,
           "options": [],
@@ -5412,7 +7271,18 @@
             385,
             42
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              385,
+              12
+            ],
+            "end": [
+              385,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "F_Bool",
           "id": 1,
           "options": [
@@ -5460,7 +7330,18 @@
             386,
             42
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              386,
+              12
+            ],
+            "end": [
+              386,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "F_Int32",
           "id": 2,
           "options": [
@@ -5508,7 +7389,18 @@
             387,
             42
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              387,
+              12
+            ],
+            "end": [
+              387,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "F_Int64",
           "id": 3,
           "options": [
@@ -5556,7 +7448,18 @@
             388,
             47
           ],
-          "fieldType": "fixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              388,
+              12
+            ],
+            "end": [
+              388,
+              18
+            ],
+            "name": "fixed32"
+          },
           "name": "F_Fixed32",
           "id": 4,
           "options": [
@@ -5604,7 +7507,18 @@
             389,
             47
           ],
-          "fieldType": "fixed64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              389,
+              12
+            ],
+            "end": [
+              389,
+              18
+            ],
+            "name": "fixed64"
+          },
           "name": "F_Fixed64",
           "id": 5,
           "options": [
@@ -5652,7 +7566,18 @@
             390,
             46
           ],
-          "fieldType": "uint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              390,
+              12
+            ],
+            "end": [
+              390,
+              17
+            ],
+            "name": "uint32"
+          },
           "name": "F_Uint32",
           "id": 6,
           "options": [
@@ -5700,7 +7625,18 @@
             391,
             46
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              391,
+              12
+            ],
+            "end": [
+              391,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "F_Uint64",
           "id": 7,
           "options": [
@@ -5748,7 +7684,18 @@
             392,
             47
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              392,
+              12
+            ],
+            "end": [
+              392,
+              16
+            ],
+            "name": "float"
+          },
           "name": "F_Float",
           "id": 8,
           "options": [
@@ -5796,7 +7743,18 @@
             393,
             49
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              393,
+              12
+            ],
+            "end": [
+              393,
+              17
+            ],
+            "name": "double"
+          },
           "name": "F_Double",
           "id": 9,
           "options": [
@@ -5844,7 +7802,18 @@
             394,
             64
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              394,
+              12
+            ],
+            "end": [
+              394,
+              17
+            ],
+            "name": "string"
+          },
           "name": "F_String",
           "id": 10,
           "options": [
@@ -5892,7 +7861,18 @@
             395,
             50
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              395,
+              12
+            ],
+            "end": [
+              395,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "F_Bytes",
           "id": 11,
           "options": [
@@ -5940,7 +7920,18 @@
             396,
             46
           ],
-          "fieldType": "sint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              396,
+              12
+            ],
+            "end": [
+              396,
+              17
+            ],
+            "name": "sint32"
+          },
           "name": "F_Sint32",
           "id": 12,
           "options": [
@@ -5988,7 +7979,18 @@
             397,
             46
           ],
-          "fieldType": "sint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              397,
+              12
+            ],
+            "end": [
+              397,
+              17
+            ],
+            "name": "sint64"
+          },
           "name": "F_Sint64",
           "id": 13,
           "options": [
@@ -6036,7 +8038,18 @@
             398,
             45
           ],
-          "fieldType": "Color",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              398,
+              12
+            ],
+            "end": [
+              398,
+              16
+            ],
+            "name": "Color"
+          },
           "name": "F_Enum",
           "id": 14,
           "options": [
@@ -6084,7 +8097,18 @@
             401,
             43
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              401,
+              12
+            ],
+            "end": [
+              401,
+              16
+            ],
+            "name": "float"
+          },
           "name": "F_Pinf",
           "id": 15,
           "options": [
@@ -6132,7 +8156,18 @@
             402,
             44
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              402,
+              12
+            ],
+            "end": [
+              402,
+              16
+            ],
+            "name": "float"
+          },
           "name": "F_Ninf",
           "id": 16,
           "options": [
@@ -6180,7 +8215,18 @@
             403,
             42
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              403,
+              12
+            ],
+            "end": [
+              403,
+              16
+            ],
+            "name": "float"
+          },
           "name": "F_Nan",
           "id": 17,
           "options": [
@@ -6228,7 +8274,18 @@
             406,
             32
           ],
-          "fieldType": "SubDefaults",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              406,
+              12
+            ],
+            "end": [
+              406,
+              22
+            ],
+            "name": "SubDefaults"
+          },
           "name": "sub",
           "id": 18,
           "options": [],
@@ -6246,7 +8303,18 @@
             409,
             45
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              409,
+              12
+            ],
+            "end": [
+              409,
+              17
+            ],
+            "name": "string"
+          },
           "name": "str_zero",
           "id": 19,
           "options": [
@@ -6308,7 +8376,18 @@
             413,
             35
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              413,
+              12
+            ],
+            "end": [
+              413,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "n",
           "id": 1,
           "options": [
@@ -6397,7 +8476,18 @@
             420,
             27
           ],
-          "fieldType": "Color",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              420,
+              12
+            ],
+            "end": [
+              420,
+              16
+            ],
+            "name": "Color"
+          },
           "name": "color",
           "id": 1,
           "options": [],
@@ -6429,7 +8519,18 @@
             424,
             26
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              424,
+              12
+            ],
+            "end": [
+              424,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "bools",
           "id": 1,
           "options": [],
@@ -6447,7 +8548,18 @@
             425,
             47
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              425,
+              12
+            ],
+            "end": [
+              425,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "bools_packed",
           "id": 2,
           "options": [
@@ -6495,7 +8607,18 @@
             426,
             26
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              426,
+              12
+            ],
+            "end": [
+              426,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "ints",
           "id": 3,
           "options": [],
@@ -6513,7 +8636,18 @@
             427,
             47
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              427,
+              12
+            ],
+            "end": [
+              427,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "ints_packed",
           "id": 4,
           "options": [
@@ -6561,7 +8695,18 @@
             428,
             49
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              428,
+              12
+            ],
+            "end": [
+              428,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "int64s_packed",
           "id": 7,
           "options": [
@@ -6609,7 +8754,18 @@
             429,
             30
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              429,
+              12
+            ],
+            "end": [
+              429,
+              17
+            ],
+            "name": "string"
+          },
           "name": "strings",
           "id": 5,
           "options": [],
@@ -6627,7 +8783,18 @@
             430,
             30
           ],
-          "fieldType": "fixed32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              430,
+              12
+            ],
+            "end": [
+              430,
+              18
+            ],
+            "name": "fixed32"
+          },
           "name": "fixeds",
           "id": 6,
           "options": [],
@@ -6675,7 +8842,18 @@
                 438,
                 25
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  438,
+                  14
+                ],
+                "end": [
+                  438,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "x",
               "id": 2,
               "options": [],
@@ -6725,7 +8903,18 @@
                 444,
                 25
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  444,
+                  14
+                ],
+                "end": [
+                  444,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "x",
               "id": 2,
               "options": [],
@@ -6743,7 +8932,18 @@
                 445,
                 25
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  445,
+                  14
+                ],
+                "end": [
+                  445,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "y",
               "id": 3,
               "options": [],
@@ -6777,7 +8977,18 @@
             450,
             24
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              450,
+              12
+            ],
+            "end": [
+              450,
+              17
+            ],
+            "name": "double"
+          },
           "name": "f",
           "id": 1,
           "options": [],
@@ -6795,7 +9006,18 @@
             451,
             26
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              451,
+              12
+            ],
+            "end": [
+              451,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "exact",
           "id": 2,
           "options": [],
@@ -6828,7 +9050,18 @@
             38
           ],
           "keyType": "int32",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              455,
+              14
+            ],
+            "end": [
+              455,
+              19
+            ],
+            "name": "string"
+          },
           "name": "name_mapping",
           "id": 1
         },
@@ -6843,7 +9076,18 @@
             45
           ],
           "keyType": "sint64",
-          "valueType": "FloatingPoint",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              456,
+              15
+            ],
+            "end": [
+              456,
+              27
+            ],
+            "name": "FloatingPoint"
+          },
           "name": "msg_mapping",
           "id": 2
         },
@@ -6858,7 +9102,18 @@
             36
           ],
           "keyType": "bool",
-          "valueType": "bytes",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              457,
+              13
+            ],
+            "end": [
+              457,
+              17
+            ],
+            "name": "bytes"
+          },
           "name": "byte_mapping",
           "id": 3
         },
@@ -6873,7 +9128,18 @@
             37
           ],
           "keyType": "string",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              458,
+              15
+            ],
+            "end": [
+              458,
+              20
+            ],
+            "name": "string"
+          },
           "name": "str_to_str",
           "id": 4
         }
@@ -6913,7 +9179,18 @@
                 463,
                 20
               ],
-              "fieldType": "bool",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  463,
+                  5
+                ],
+                "end": [
+                  463,
+                  8
+                ],
+                "name": "bool"
+              },
               "name": "F_Bool",
               "id": 1,
               "options": [],
@@ -6931,7 +9208,18 @@
                 464,
                 22
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  464,
+                  5
+                ],
+                "end": [
+                  464,
+                  9
+                ],
+                "name": "int32"
+              },
               "name": "F_Int32",
               "id": 2,
               "options": [],
@@ -6949,7 +9237,18 @@
                 465,
                 22
               ],
-              "fieldType": "int64",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  465,
+                  5
+                ],
+                "end": [
+                  465,
+                  9
+                ],
+                "name": "int64"
+              },
               "name": "F_Int64",
               "id": 3,
               "options": [],
@@ -6967,7 +9266,18 @@
                 466,
                 26
               ],
-              "fieldType": "fixed32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  466,
+                  5
+                ],
+                "end": [
+                  466,
+                  11
+                ],
+                "name": "fixed32"
+              },
               "name": "F_Fixed32",
               "id": 4,
               "options": [],
@@ -6985,7 +9295,18 @@
                 467,
                 26
               ],
-              "fieldType": "fixed64",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  467,
+                  5
+                ],
+                "end": [
+                  467,
+                  11
+                ],
+                "name": "fixed64"
+              },
               "name": "F_Fixed64",
               "id": 5,
               "options": [],
@@ -7003,7 +9324,18 @@
                 468,
                 24
               ],
-              "fieldType": "uint32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  468,
+                  5
+                ],
+                "end": [
+                  468,
+                  10
+                ],
+                "name": "uint32"
+              },
               "name": "F_Uint32",
               "id": 6,
               "options": [],
@@ -7021,7 +9353,18 @@
                 469,
                 24
               ],
-              "fieldType": "uint64",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  469,
+                  5
+                ],
+                "end": [
+                  469,
+                  10
+                ],
+                "name": "uint64"
+              },
               "name": "F_Uint64",
               "id": 7,
               "options": [],
@@ -7039,7 +9382,18 @@
                 470,
                 22
               ],
-              "fieldType": "float",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  470,
+                  5
+                ],
+                "end": [
+                  470,
+                  9
+                ],
+                "name": "float"
+              },
               "name": "F_Float",
               "id": 8,
               "options": [],
@@ -7057,7 +9411,18 @@
                 471,
                 24
               ],
-              "fieldType": "double",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  471,
+                  5
+                ],
+                "end": [
+                  471,
+                  10
+                ],
+                "name": "double"
+              },
               "name": "F_Double",
               "id": 9,
               "options": [],
@@ -7075,7 +9440,18 @@
                 472,
                 25
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  472,
+                  5
+                ],
+                "end": [
+                  472,
+                  10
+                ],
+                "name": "string"
+              },
               "name": "F_String",
               "id": 10,
               "options": [],
@@ -7093,7 +9469,18 @@
                 473,
                 23
               ],
-              "fieldType": "bytes",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  473,
+                  5
+                ],
+                "end": [
+                  473,
+                  9
+                ],
+                "name": "bytes"
+              },
               "name": "F_Bytes",
               "id": 11,
               "options": [],
@@ -7111,7 +9498,18 @@
                 474,
                 25
               ],
-              "fieldType": "sint32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  474,
+                  5
+                ],
+                "end": [
+                  474,
+                  10
+                ],
+                "name": "sint32"
+              },
               "name": "F_Sint32",
               "id": 12,
               "options": [],
@@ -7129,7 +9527,18 @@
                 475,
                 25
               ],
-              "fieldType": "sint64",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  475,
+                  5
+                ],
+                "end": [
+                  475,
+                  10
+                ],
+                "name": "sint64"
+              },
               "name": "F_Sint64",
               "id": 13,
               "options": [],
@@ -7147,7 +9556,18 @@
                 476,
                 32
               ],
-              "fieldType": "MyMessage.Color",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  476,
+                  5
+                ],
+                "end": [
+                  476,
+                  19
+                ],
+                "name": "MyMessage.Color"
+              },
               "name": "F_Enum",
               "id": 14,
               "options": [],
@@ -7165,7 +9585,18 @@
                 477,
                 31
               ],
-              "fieldType": "GoTestField",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  477,
+                  5
+                ],
+                "end": [
+                  477,
+                  15
+                ],
+                "name": "GoTestField"
+              },
               "name": "F_Message",
               "id": 15,
               "options": [],
@@ -7199,7 +9630,18 @@
                     479,
                     28
                   ],
-                  "fieldType": "int32",
+                  "fieldType": {
+                    "type": "Type",
+                    "start": [
+                      479,
+                      16
+                    ],
+                    "end": [
+                      479,
+                      20
+                    ],
+                    "name": "int32"
+                  },
                   "name": "x",
                   "id": 17,
                   "options": [],
@@ -7219,7 +9661,18 @@
                 481,
                 36
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  481,
+                  5
+                ],
+                "end": [
+                  481,
+                  9
+                ],
+                "name": "int32"
+              },
               "name": "F_Largest_Tag",
               "id": 536870911,
               "options": [],
@@ -7251,7 +9704,18 @@
                 485,
                 22
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  485,
+                  5
+                ],
+                "end": [
+                  485,
+                  9
+                ],
+                "name": "int32"
+              },
               "name": "value",
               "id": 100,
               "options": [],
@@ -7285,7 +9749,18 @@
             490,
             32
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              490,
+              12
+            ],
+            "end": [
+              490,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "make_me_cry",
           "id": 1,
           "options": [],
@@ -7315,7 +9790,18 @@
                 494,
                 21
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  494,
+                  5
+                ],
+                "end": [
+                  494,
+                  9
+                ],
+                "name": "int32"
+              },
               "name": "number",
               "id": 5,
               "options": [],
@@ -7333,7 +9819,18 @@
                 495,
                 20
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  495,
+                  5
+                ],
+                "end": [
+                  495,
+                  10
+                ],
+                "name": "string"
+              },
               "name": "name",
               "id": 6,
               "options": [],
@@ -7351,7 +9848,18 @@
                 496,
                 19
               ],
-              "fieldType": "bytes",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  496,
+                  5
+                ],
+                "end": [
+                  496,
+                  9
+                ],
+                "name": "bytes"
+              },
               "name": "data",
               "id": 7,
               "options": [],
@@ -7369,7 +9877,18 @@
                 497,
                 22
               ],
-              "fieldType": "double",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  497,
+                  5
+                ],
+                "end": [
+                  497,
+                  10
+                ],
+                "name": "double"
+              },
               "name": "temp_c",
               "id": 8,
               "options": [],
@@ -7387,7 +9906,18 @@
                 498,
                 28
               ],
-              "fieldType": "MyMessage.Color",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  498,
+                  5
+                ],
+                "end": [
+                  498,
+                  19
+                ],
+                "name": "MyMessage.Color"
+              },
               "name": "col",
               "id": 9,
               "options": [],
@@ -7405,7 +9935,18 @@
                 499,
                 21
               ],
-              "fieldType": "Strings",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  499,
+                  5
+                ],
+                "end": [
+                  499,
+                  11
+                ],
+                "name": "Strings"
+              },
               "name": "msg",
               "id": 10,
               "options": [],
@@ -7439,7 +9980,18 @@
             504,
             29
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              504,
+              12
+            ],
+            "end": [
+              504,
+              17
+            ],
+            "name": "string"
+          },
           "name": "scalar",
           "id": 1,
           "options": [],
@@ -7457,7 +10009,18 @@
             505,
             29
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              505,
+              12
+            ],
+            "end": [
+              505,
+              17
+            ],
+            "name": "string"
+          },
           "name": "vector",
           "id": 2,
           "options": [],
@@ -7487,7 +10050,18 @@
                 506,
                 33
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  506,
+                  17
+                ],
+                "end": [
+                  506,
+                  22
+                ],
+                "name": "string"
+              },
               "name": "field",
               "id": 3,
               "options": [],
@@ -7508,7 +10082,18 @@
             33
           ],
           "keyType": "string",
-          "valueType": "int64",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              507,
+              15
+            ],
+            "end": [
+              507,
+              19
+            ],
+            "name": "int64"
+          },
           "name": "map_key",
           "id": 4
         },
@@ -7523,7 +10108,18 @@
             35
           ],
           "keyType": "int64",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              508,
+              14
+            ],
+            "end": [
+              508,
+              19
+            ],
+            "name": "string"
+          },
           "name": "map_value",
           "id": 5
         }

--- a/testdata/golang-proto3-test.ast.json
+++ b/testdata/golang-proto3-test.ast.json
@@ -178,7 +178,18 @@
             46,
             18
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              46,
+              3
+            ],
+            "end": [
+              46,
+              8
+            ],
+            "name": "string"
+          },
           "name": "name",
           "id": 1,
           "options": [],
@@ -196,7 +207,18 @@
             47,
             22
           ],
-          "fieldType": "Humour",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              47,
+              3
+            ],
+            "end": [
+              47,
+              8
+            ],
+            "name": "Humour"
+          },
           "name": "hilarity",
           "id": 2,
           "options": [],
@@ -214,7 +236,18 @@
             48,
             26
           ],
-          "fieldType": "uint32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              48,
+              3
+            ],
+            "end": [
+              48,
+              8
+            ],
+            "name": "uint32"
+          },
           "name": "height_in_cm",
           "id": 3,
           "options": [],
@@ -232,7 +265,18 @@
             49,
             17
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              49,
+              3
+            ],
+            "end": [
+              49,
+              7
+            ],
+            "name": "bytes"
+          },
           "name": "data",
           "id": 4,
           "options": [],
@@ -250,7 +294,18 @@
             50,
             25
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              50,
+              3
+            ],
+            "end": [
+              50,
+              7
+            ],
+            "name": "int64"
+          },
           "name": "result_count",
           "id": 7,
           "options": [],
@@ -268,7 +323,18 @@
             51,
             25
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              51,
+              3
+            ],
+            "end": [
+              51,
+              6
+            ],
+            "name": "bool"
+          },
           "name": "true_scotsman",
           "id": 8,
           "options": [],
@@ -286,7 +352,18 @@
             52,
             18
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              52,
+              3
+            ],
+            "end": [
+              52,
+              7
+            ],
+            "name": "float"
+          },
           "name": "score",
           "id": 9,
           "options": [],
@@ -304,7 +381,18 @@
             54,
             26
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              54,
+              12
+            ],
+            "end": [
+              54,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "key",
           "id": 5,
           "options": [],
@@ -322,7 +410,18 @@
             55,
             32
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              55,
+              12
+            ],
+            "end": [
+              55,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "short_key",
           "id": 19,
           "options": [],
@@ -340,7 +439,18 @@
             56,
             20
           ],
-          "fieldType": "Nested",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              56,
+              3
+            ],
+            "end": [
+              56,
+              8
+            ],
+            "name": "Nested"
+          },
           "name": "nested",
           "id": 6,
           "options": [],
@@ -358,7 +468,18 @@
             57,
             31
           ],
-          "fieldType": "Humour",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              57,
+              12
+            ],
+            "end": [
+              57,
+              17
+            ],
+            "name": "Humour"
+          },
           "name": "r_funny",
           "id": 16,
           "options": [],
@@ -377,7 +498,18 @@
             35
           ],
           "keyType": "string",
-          "valueType": "Nested",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              59,
+              15
+            ],
+            "end": [
+              59,
+              20
+            ],
+            "name": "Nested"
+          },
           "name": "terrain",
           "id": 10
         },
@@ -391,7 +523,18 @@
             60,
             44
           ],
-          "fieldType": "proto2_test.SubDefaults",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              60,
+              3
+            ],
+            "end": [
+              60,
+              25
+            ],
+            "name": "proto2_test.SubDefaults"
+          },
           "name": "proto2_field",
           "id": 11,
           "options": [],
@@ -410,7 +553,18 @@
             57
           ],
           "keyType": "string",
-          "valueType": "proto2_test.SubDefaults",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              61,
+              15
+            ],
+            "end": [
+              61,
+              37
+            ],
+            "name": "proto2_test.SubDefaults"
+          },
           "name": "proto2_value",
           "id": 13
         },
@@ -424,7 +578,18 @@
             63,
             36
           ],
-          "fieldType": "google.protobuf.Any",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              63,
+              3
+            ],
+            "end": [
+              63,
+              21
+            ],
+            "name": "google.protobuf.Any"
+          },
           "name": "anything",
           "id": 14,
           "options": [],
@@ -442,7 +607,18 @@
             64,
             48
           ],
-          "fieldType": "google.protobuf.Any",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              64,
+              12
+            ],
+            "end": [
+              64,
+              30
+            ],
+            "name": "google.protobuf.Any"
+          },
           "name": "many_things",
           "id": 15,
           "options": [],
@@ -460,7 +636,18 @@
             66,
             26
           ],
-          "fieldType": "Message",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              66,
+              3
+            ],
+            "end": [
+              66,
+              9
+            ],
+            "name": "Message"
+          },
           "name": "submessage",
           "id": 17,
           "options": [],
@@ -478,7 +665,18 @@
             67,
             33
           ],
-          "fieldType": "Message",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              67,
+              12
+            ],
+            "end": [
+              67,
+              18
+            ],
+            "name": "Message"
+          },
           "name": "children",
           "id": 18,
           "options": [],
@@ -497,7 +695,18 @@
             38
           ],
           "keyType": "string",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              69,
+              15
+            ],
+            "end": [
+              69,
+              20
+            ],
+            "name": "string"
+          },
           "name": "string_map",
           "id": 20
         }
@@ -525,7 +734,18 @@
             73,
             19
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              73,
+              3
+            ],
+            "end": [
+              73,
+              8
+            ],
+            "name": "string"
+          },
           "name": "bunny",
           "id": 1,
           "options": [],
@@ -543,7 +763,18 @@
             74,
             16
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              74,
+              3
+            ],
+            "end": [
+              74,
+              6
+            ],
+            "name": "bool"
+          },
           "name": "cute",
           "id": 2,
           "options": [],
@@ -576,7 +807,18 @@
             36
           ],
           "keyType": "bool",
-          "valueType": "bytes",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              78,
+              13
+            ],
+            "end": [
+              78,
+              17
+            ],
+            "name": "bytes"
+          },
           "name": "byte_mapping",
           "id": 1
         }
@@ -605,7 +847,18 @@
             28
           ],
           "keyType": "int32",
-          "valueType": "int32",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              83,
+              14
+            ],
+            "end": [
+              83,
+              18
+            ],
+            "name": "int32"
+          },
           "name": "rtt",
           "id": 1
         }
@@ -633,7 +886,18 @@
             87,
             27
           ],
-          "fieldType": "IntMap",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              87,
+              12
+            ],
+            "end": [
+              87,
+              17
+            ],
+            "name": "IntMap"
+          },
           "name": "maps",
           "id": 1,
           "options": [],
@@ -665,7 +929,18 @@
             91,
             20
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              91,
+              3
+            ],
+            "end": [
+              91,
+              8
+            ],
+            "name": "string"
+          },
           "name": "scalar",
           "id": 1,
           "options": [],
@@ -683,7 +958,18 @@
             92,
             29
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              92,
+              12
+            ],
+            "end": [
+              92,
+              17
+            ],
+            "name": "string"
+          },
           "name": "vector",
           "id": 2,
           "options": [],
@@ -713,7 +999,18 @@
                 93,
                 33
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  93,
+                  17
+                ],
+                "end": [
+                  93,
+                  22
+                ],
+                "name": "string"
+              },
               "name": "field",
               "id": 3,
               "options": [],
@@ -734,7 +1031,18 @@
             33
           ],
           "keyType": "string",
-          "valueType": "int64",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              94,
+              15
+            ],
+            "end": [
+              94,
+              19
+            ],
+            "name": "int64"
+          },
           "name": "map_key",
           "id": 4
         },
@@ -749,7 +1057,18 @@
             35
           ],
           "keyType": "int64",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              95,
+              14
+            ],
+            "end": [
+              95,
+              19
+            ],
+            "name": "string"
+          },
           "name": "map_value",
           "id": 5
         }

--- a/testdata/leadingdot.ast.json
+++ b/testdata/leadingdot.ast.json
@@ -56,7 +56,18 @@
             5,
             30
           ],
-          "fieldType": ".Foo.Bar",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              5,
+              12
+            ],
+            "end": [
+              5,
+              19
+            ],
+            "name": ".Foo.Bar"
+          },
           "name": "thing",
           "id": 1,
           "options": [],

--- a/testdata/rpc1.ast.json
+++ b/testdata/rpc1.ast.json
@@ -45,11 +45,33 @@
           ],
           "name": "MyMethod",
           "request": {
-            "name": "MyRequest",
+            "name": {
+              "type": "Type",
+              "start": [
+                4,
+                19
+              ],
+              "end": [
+                4,
+                27
+              ],
+              "name": "MyRequest"
+            },
             "streaming": false
           },
           "response": {
-            "name": "MyResponse",
+            "name": {
+              "type": "Type",
+              "start": [
+                4,
+                39
+              ],
+              "end": [
+                4,
+                48
+              ],
+              "name": "MyResponse"
+            },
             "streaming": false
           },
           "body": null
@@ -78,7 +100,18 @@
             8,
             20
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              8,
+              5
+            ],
+            "end": [
+              8,
+              10
+            ],
+            "name": "string"
+          },
           "name": "path",
           "id": 1,
           "options": [],
@@ -110,7 +143,18 @@
             12,
             21
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              12,
+              5
+            ],
+            "end": [
+              12,
+              9
+            ],
+            "name": "int32"
+          },
           "name": "status",
           "id": 2,
           "options": [],

--- a/testdata/test1.ast.json
+++ b/testdata/test1.ast.json
@@ -180,7 +180,18 @@
             51,
             36
           ],
-          "fieldType": "OuterEnum",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              51,
+              12
+            ],
+            "end": [
+              51,
+              20
+            ],
+            "name": "OuterEnum"
+          },
           "name": "outer_enum",
           "id": 1,
           "options": [],
@@ -212,7 +223,18 @@
             55,
             31
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              55,
+              12
+            ],
+            "end": [
+              55,
+              17
+            ],
+            "name": "string"
+          },
           "name": "a_string",
           "id": 1,
           "options": [],
@@ -230,7 +252,18 @@
             56,
             40
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              56,
+              12
+            ],
+            "end": [
+              56,
+              17
+            ],
+            "name": "string"
+          },
           "name": "a_repeated_string",
           "id": 2,
           "options": [],
@@ -248,7 +281,18 @@
             57,
             30
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              57,
+              12
+            ],
+            "end": [
+              57,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "a_boolean",
           "id": 3,
           "options": [],
@@ -280,7 +324,18 @@
             62,
             31
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              62,
+              12
+            ],
+            "end": [
+              62,
+              17
+            ],
+            "name": "string"
+          },
           "name": "a_string",
           "id": 1,
           "options": [],
@@ -298,7 +353,18 @@
             63,
             40
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              63,
+              12
+            ],
+            "end": [
+              63,
+              17
+            ],
+            "name": "string"
+          },
           "name": "a_repeated_string",
           "id": 2,
           "options": [],
@@ -330,7 +396,18 @@
             67,
             29
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              67,
+              12
+            ],
+            "end": [
+              67,
+              17
+            ],
+            "name": "string"
+          },
           "name": "normal",
           "id": 1,
           "options": [],
@@ -348,7 +425,18 @@
             69,
             30
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              69,
+              12
+            ],
+            "end": [
+              69,
+              17
+            ],
+            "name": "string"
+          },
           "name": "default",
           "id": 2,
           "options": [],
@@ -366,7 +454,18 @@
             70,
             31
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              70,
+              12
+            ],
+            "end": [
+              70,
+              17
+            ],
+            "name": "string"
+          },
           "name": "function",
           "id": 3,
           "options": [],
@@ -384,7 +483,18 @@
             71,
             26
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              71,
+              12
+            ],
+            "end": [
+              71,
+              17
+            ],
+            "name": "string"
+          },
           "name": "var",
           "id": 4,
           "options": [],
@@ -428,7 +538,18 @@
                 76,
                 30
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  76,
+                  14
+                ],
+                "end": [
+                  76,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "an_int",
               "id": 1,
               "options": [],
@@ -448,7 +569,18 @@
             78,
             31
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              78,
+              12
+            ],
+            "end": [
+              78,
+              17
+            ],
+            "name": "string"
+          },
           "name": "a_string",
           "id": 1,
           "options": [],
@@ -466,7 +598,18 @@
             79,
             27
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              79,
+              12
+            ],
+            "end": [
+              79,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "a_bool",
           "id": 2,
           "options": [],
@@ -484,7 +627,18 @@
             80,
             39
           ],
-          "fieldType": "Nested",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              80,
+              12
+            ],
+            "end": [
+              80,
+              17
+            ],
+            "name": "Nested"
+          },
           "name": "a_nested_message",
           "id": 3,
           "options": [],
@@ -502,7 +656,18 @@
             81,
             41
           ],
-          "fieldType": "Nested",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              81,
+              12
+            ],
+            "end": [
+              81,
+              17
+            ],
+            "name": "Nested"
+          },
           "name": "a_repeated_message",
           "id": 4,
           "options": [],
@@ -520,7 +685,18 @@
             82,
             40
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              82,
+              12
+            ],
+            "end": [
+              82,
+              17
+            ],
+            "name": "string"
+          },
           "name": "a_repeated_string",
           "id": 5,
           "options": [],
@@ -552,7 +728,18 @@
             86,
             27
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              86,
+              12
+            ],
+            "end": [
+              86,
+              17
+            ],
+            "name": "string"
+          },
           "name": "str1",
           "id": 1,
           "options": [],
@@ -570,7 +757,18 @@
             87,
             27
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              87,
+              12
+            ],
+            "end": [
+              87,
+              17
+            ],
+            "name": "string"
+          },
           "name": "str2",
           "id": 2,
           "options": [],
@@ -588,7 +786,18 @@
             88,
             27
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              88,
+              12
+            ],
+            "end": [
+              88,
+              17
+            ],
+            "name": "string"
+          },
           "name": "str3",
           "id": 3,
           "options": [],
@@ -649,7 +858,18 @@
                 94,
                 30
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  94,
+                  14
+                ],
+                "end": [
+                  94,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "an_int",
               "id": 2,
               "options": [],
@@ -669,7 +889,18 @@
             96,
             31
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              96,
+              12
+            ],
+            "end": [
+              96,
+              17
+            ],
+            "name": "string"
+          },
           "name": "a_string",
           "id": 1,
           "options": [],
@@ -687,7 +918,18 @@
             97,
             41
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              97,
+              12
+            ],
+            "end": [
+              97,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "an_out_of_order_bool",
           "id": 9,
           "options": [],
@@ -705,7 +947,18 @@
             98,
             39
           ],
-          "fieldType": "Nested",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              98,
+              12
+            ],
+            "end": [
+              98,
+              17
+            ],
+            "name": "Nested"
+          },
           "name": "a_nested_message",
           "id": 4,
           "options": [],
@@ -723,7 +976,18 @@
             99,
             41
           ],
-          "fieldType": "Nested",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              99,
+              12
+            ],
+            "end": [
+              99,
+              17
+            ],
+            "name": "Nested"
+          },
           "name": "a_repeated_message",
           "id": 5,
           "options": [],
@@ -741,7 +1005,18 @@
             100,
             40
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              100,
+              12
+            ],
+            "end": [
+              100,
+              17
+            ],
+            "name": "string"
+          },
           "name": "a_repeated_string",
           "id": 7,
           "options": [],
@@ -759,7 +1034,18 @@
             101,
             46
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              101,
+              12
+            ],
+            "end": [
+              101,
+              17
+            ],
+            "name": "double"
+          },
           "name": "a_floating_point_field",
           "id": 10,
           "options": [],
@@ -803,7 +1089,18 @@
                 107,
                 43
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  107,
+                  14
+                ],
+                "end": [
+                  107,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "inner_complex_field",
               "id": 1,
               "options": [],
@@ -837,7 +1134,18 @@
             115,
             29
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              115,
+              12
+            ],
+            "end": [
+              115,
+              17
+            ],
+            "name": "string"
+          },
           "name": "cookie",
           "id": 1,
           "options": [],
@@ -881,7 +1189,18 @@
                 120,
                 41
               ],
-              "fieldType": "IsExtension",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  120,
+                  14
+                ],
+                "end": [
+                  120,
+                  24
+                ],
+                "name": "IsExtension"
+              },
               "name": "ext_field",
               "id": 100,
               "options": [],
@@ -901,7 +1220,18 @@
             122,
             27
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              122,
+              12
+            ],
+            "end": [
+              122,
+              17
+            ],
+            "name": "string"
+          },
           "name": "ext1",
           "id": 1,
           "options": [],
@@ -931,7 +1261,18 @@
                 126,
                 45
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  126,
+                  14
+                ],
+                "end": [
+                  126,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "simple_option",
               "id": 42113038,
               "options": [],
@@ -977,7 +1318,18 @@
                 132,
                 34
               ],
-              "fieldType": "Simple1",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  132,
+                  14
+                ],
+                "end": [
+                  132,
+                  20
+                ],
+                "name": "Simple1"
+              },
               "name": "simple",
               "id": 101,
               "options": [],
@@ -995,7 +1347,18 @@
                 133,
                 30
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  133,
+                  14
+                ],
+                "end": [
+                  133,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "str",
               "id": 102,
               "options": [],
@@ -1013,7 +1376,18 @@
                 134,
                 39
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  134,
+                  14
+                ],
+                "end": [
+                  134,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "repeated_str",
               "id": 103,
               "options": [],
@@ -1031,7 +1405,18 @@
                 135,
                 43
               ],
-              "fieldType": "Simple1",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  135,
+                  14
+                ],
+                "end": [
+                  135,
+                  20
+                ],
+                "name": "Simple1"
+              },
               "name": "repeated_simple",
               "id": 104,
               "options": [],
@@ -1065,7 +1450,18 @@
             140,
             33
           ],
-          "fieldType": "Simple1",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              140,
+              12
+            ],
+            "end": [
+              140,
+              18
+            ],
+            "name": "Simple1"
+          },
           "name": "simple1",
           "id": 105,
           "options": [],
@@ -1137,7 +1533,18 @@
             148,
             66
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              148,
+              12
+            ],
+            "end": [
+              148,
+              17
+            ],
+            "name": "string"
+          },
           "name": "string_field",
           "id": 1,
           "options": [
@@ -1185,7 +1592,18 @@
             149,
             48
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              149,
+              12
+            ],
+            "end": [
+              149,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "bool_field",
           "id": 2,
           "options": [
@@ -1233,7 +1651,18 @@
             150,
             46
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              150,
+              12
+            ],
+            "end": [
+              150,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "int_field",
           "id": 3,
           "options": [
@@ -1281,7 +1710,18 @@
             151,
             46
           ],
-          "fieldType": "Enum",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              151,
+              12
+            ],
+            "end": [
+              151,
+              15
+            ],
+            "name": "Enum"
+          },
           "name": "enum_field",
           "id": 4,
           "options": [
@@ -1329,7 +1769,18 @@
             152,
             49
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              152,
+              12
+            ],
+            "end": [
+              152,
+              17
+            ],
+            "name": "string"
+          },
           "name": "empty_field",
           "id": 6,
           "options": [
@@ -1377,7 +1828,18 @@
             154,
             24
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              153,
+              12
+            ],
+            "end": [
+              153,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "bytes_field",
           "id": 8,
           "options": [
@@ -1439,7 +1901,18 @@
             158,
             42
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              158,
+              12
+            ],
+            "end": [
+              158,
+              16
+            ],
+            "name": "float"
+          },
           "name": "optional_float_field",
           "id": 1,
           "options": [],
@@ -1457,7 +1930,18 @@
             159,
             42
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              159,
+              12
+            ],
+            "end": [
+              159,
+              16
+            ],
+            "name": "float"
+          },
           "name": "required_float_field",
           "id": 2,
           "options": [],
@@ -1475,7 +1959,18 @@
             160,
             42
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              160,
+              12
+            ],
+            "end": [
+              160,
+              16
+            ],
+            "name": "float"
+          },
           "name": "repeated_float_field",
           "id": 3,
           "options": [],
@@ -1493,7 +1988,18 @@
             161,
             57
           ],
-          "fieldType": "float",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              161,
+              12
+            ],
+            "end": [
+              161,
+              16
+            ],
+            "name": "float"
+          },
           "name": "default_float_field",
           "id": 4,
           "options": [
@@ -1541,7 +2047,18 @@
             162,
             44
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              162,
+              12
+            ],
+            "end": [
+              162,
+              17
+            ],
+            "name": "double"
+          },
           "name": "optional_double_field",
           "id": 5,
           "options": [],
@@ -1559,7 +2076,18 @@
             163,
             44
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              163,
+              12
+            ],
+            "end": [
+              163,
+              17
+            ],
+            "name": "double"
+          },
           "name": "required_double_field",
           "id": 6,
           "options": [],
@@ -1577,7 +2105,18 @@
             164,
             44
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              164,
+              12
+            ],
+            "end": [
+              164,
+              17
+            ],
+            "name": "double"
+          },
           "name": "repeated_double_field",
           "id": 7,
           "options": [],
@@ -1595,7 +2134,18 @@
             165,
             59
           ],
-          "fieldType": "double",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              165,
+              12
+            ],
+            "end": [
+              165,
+              17
+            ],
+            "name": "double"
+          },
           "name": "default_double_field",
           "id": 8,
           "options": [
@@ -1657,7 +2207,18 @@
             169,
             43
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              169,
+              12
+            ],
+            "end": [
+              169,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "optional_boolean_field",
           "id": 1,
           "options": [],
@@ -1675,7 +2236,18 @@
             170,
             43
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              170,
+              12
+            ],
+            "end": [
+              170,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "required_boolean_field",
           "id": 2,
           "options": [],
@@ -1693,7 +2265,18 @@
             171,
             43
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              171,
+              12
+            ],
+            "end": [
+              171,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "repeated_boolean_field",
           "id": 3,
           "options": [],
@@ -1711,7 +2294,18 @@
             172,
             59
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              172,
+              12
+            ],
+            "end": [
+              172,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "default_boolean_field",
           "id": 4,
           "options": [
@@ -1773,7 +2367,18 @@
             176,
             26
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              176,
+              12
+            ],
+            "end": [
+              176,
+              17
+            ],
+            "name": "string"
+          },
           "name": "str",
           "id": 1,
           "options": [],
@@ -1791,7 +2396,18 @@
             177,
             31
           ],
-          "fieldType": "Simple1",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              177,
+              12
+            ],
+            "end": [
+              177,
+              18
+            ],
+            "name": "Simple1"
+          },
           "name": "simple1",
           "id": 3,
           "options": [],
@@ -1809,7 +2425,18 @@
             178,
             31
           ],
-          "fieldType": "Simple1",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              178,
+              12
+            ],
+            "end": [
+              178,
+              18
+            ],
+            "name": "Simple1"
+          },
           "name": "simple2",
           "id": 5,
           "options": [],
@@ -1827,7 +2454,18 @@
             179,
             33
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              179,
+              12
+            ],
+            "end": [
+              179,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "bytes_field",
           "id": 6,
           "options": [],
@@ -1845,7 +2483,18 @@
             180,
             29
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              180,
+              12
+            ],
+            "end": [
+              180,
+              17
+            ],
+            "name": "string"
+          },
           "name": "unused",
           "id": 7,
           "options": [],
@@ -1906,7 +2555,18 @@
                 186,
                 45
               ],
-              "fieldType": "TestCloneExtension",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  186,
+                  14
+                ],
+                "end": [
+                  186,
+                  31
+                ],
+                "name": "TestCloneExtension"
+              },
               "name": "low_ext",
               "id": 11,
               "options": [],
@@ -1926,7 +2586,18 @@
             188,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              188,
+              12
+            ],
+            "end": [
+              188,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "f",
           "id": 1,
           "options": [],
@@ -1970,7 +2641,18 @@
                 193,
                 44
               ],
-              "fieldType": "CloneExtension",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  193,
+                  14
+                ],
+                "end": [
+                  193,
+                  27
+                ],
+                "name": "CloneExtension"
+              },
               "name": "ext_field",
               "id": 100,
               "options": [],
@@ -1990,7 +2672,18 @@
             195,
             26
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              195,
+              12
+            ],
+            "end": [
+              195,
+              17
+            ],
+            "name": "string"
+          },
           "name": "ext",
           "id": 2,
           "options": [],
@@ -2038,7 +2731,18 @@
                 200,
                 27
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  200,
+                  14
+                ],
+                "end": [
+                  200,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "id",
               "id": 1,
               "options": [],
@@ -2056,7 +2760,18 @@
                 201,
                 32
               ],
-              "fieldType": "bool",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  201,
+                  14
+                ],
+                "end": [
+                  201,
+                  17
+                ],
+                "name": "bool"
+              },
               "name": "some_bool",
               "id": 2,
               "options": [],
@@ -2092,7 +2807,18 @@
                 204,
                 27
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  204,
+                  14
+                ],
+                "end": [
+                  204,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "id",
               "id": 1,
               "options": [],
@@ -2128,7 +2854,18 @@
                 207,
                 27
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  207,
+                  14
+                ],
+                "end": [
+                  207,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "id",
               "id": 1,
               "options": [],
@@ -2148,7 +2885,18 @@
             209,
             25
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              209,
+              12
+            ],
+            "end": [
+              209,
+              17
+            ],
+            "name": "string"
+          },
           "name": "id",
           "id": 4,
           "options": [],
@@ -2166,7 +2914,18 @@
             210,
             39
           ],
-          "fieldType": "Simple2",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              210,
+              12
+            ],
+            "end": [
+              210,
+              18
+            ],
+            "name": "Simple2"
+          },
           "name": "required_simple",
           "id": 5,
           "options": [],
@@ -2184,7 +2943,18 @@
             211,
             39
           ],
-          "fieldType": "Simple2",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              211,
+              12
+            ],
+            "end": [
+              211,
+              18
+            ],
+            "name": "Simple2"
+          },
           "name": "optional_simple",
           "id": 6,
           "options": [],
@@ -2216,7 +2986,18 @@
             215,
             45
           ],
-          "fieldType": "TestGroup.RepeatedGroup",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              215,
+              12
+            ],
+            "end": [
+              215,
+              34
+            ],
+            "name": "TestGroup.RepeatedGroup"
+          },
           "name": "group",
           "id": 1,
           "options": [],
@@ -2248,7 +3029,18 @@
             219,
             31
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              219,
+              12
+            ],
+            "end": [
+              219,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "extension",
           "id": 1,
           "options": [],
@@ -2309,7 +3101,18 @@
                 225,
                 28
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  225,
+                  14
+                ],
+                "end": [
+                  225,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "foo",
               "id": 10,
               "options": [],
@@ -2355,7 +3158,18 @@
                 232,
                 20
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  232,
+                  5
+                ],
+                "end": [
+                  232,
+                  10
+                ],
+                "name": "string"
+              },
               "name": "pone",
               "id": 3,
               "options": [],
@@ -2373,7 +3187,18 @@
                 233,
                 22
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  233,
+                  5
+                ],
+                "end": [
+                  233,
+                  10
+                ],
+                "name": "string"
+              },
               "name": "pthree",
               "id": 5,
               "options": [],
@@ -2405,7 +3230,18 @@
                 237,
                 34
               ],
-              "fieldType": "TestMessageWithOneof",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  237,
+                  5
+                ],
+                "end": [
+                  237,
+                  24
+                ],
+                "name": "TestMessageWithOneof"
+              },
               "name": "rone",
               "id": 6,
               "options": [],
@@ -2423,7 +3259,18 @@
                 238,
                 20
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  238,
+                  5
+                ],
+                "end": [
+                  238,
+                  10
+                ],
+                "name": "string"
+              },
               "name": "rtwo",
               "id": 7,
               "options": [],
@@ -2443,7 +3290,18 @@
             241,
             33
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              241,
+              12
+            ],
+            "end": [
+              241,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "normal_field",
           "id": 8,
           "options": [],
@@ -2461,7 +3319,18 @@
             242,
             37
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              242,
+              12
+            ],
+            "end": [
+              242,
+              17
+            ],
+            "name": "string"
+          },
           "name": "repeated_field",
           "id": 9,
           "options": [],
@@ -2491,7 +3360,18 @@
                 245,
                 37
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  245,
+                  5
+                ],
+                "end": [
+                  245,
+                  9
+                ],
+                "name": "int32"
+              },
               "name": "aone",
               "id": 10,
               "options": [
@@ -2539,7 +3419,18 @@
                 246,
                 20
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  246,
+                  5
+                ],
+                "end": [
+                  246,
+                  9
+                ],
+                "name": "int32"
+              },
               "name": "atwo",
               "id": 11,
               "options": [],
@@ -2571,7 +3462,18 @@
                 250,
                 20
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  250,
+                  5
+                ],
+                "end": [
+                  250,
+                  9
+                ],
+                "name": "int32"
+              },
               "name": "bone",
               "id": 12,
               "options": [],
@@ -2589,7 +3491,18 @@
                 251,
                 37
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  251,
+                  5
+                ],
+                "end": [
+                  251,
+                  9
+                ],
+                "name": "int32"
+              },
               "name": "btwo",
               "id": 13,
               "options": [
@@ -2653,7 +3566,18 @@
             256,
             27
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              256,
+              12
+            ],
+            "end": [
+              256,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "value",
           "id": 1,
           "options": [],
@@ -2671,7 +3595,18 @@
             257,
             26
           ],
-          "fieldType": "bytes",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              257,
+              12
+            ],
+            "end": [
+              257,
+              16
+            ],
+            "name": "bytes"
+          },
           "name": "data",
           "id": 2,
           "options": [],
@@ -2703,7 +3638,18 @@
             263,
             45
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              263,
+              12
+            ],
+            "end": [
+              263,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "last_field_before_pivot",
           "id": 1,
           "options": [],
@@ -2752,7 +3698,18 @@
             268,
             65
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              268,
+              12
+            ],
+            "end": [
+              268,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "extend_test_last_field_before_pivot_field",
           "id": 101,
           "options": [],
@@ -2784,7 +3741,18 @@
             273,
             55
           ],
-          "fieldType": "int64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              273,
+              12
+            ],
+            "end": [
+              273,
+              16
+            ],
+            "name": "int64"
+          },
           "name": "int64_normal",
           "id": 1,
           "options": [
@@ -2832,7 +3800,18 @@
             274,
             56
           ],
-          "fieldType": "sint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              274,
+              12
+            ],
+            "end": [
+              274,
+              17
+            ],
+            "name": "sint64"
+          },
           "name": "int64_string",
           "id": 2,
           "options": [
@@ -2880,7 +3859,18 @@
             275,
             56
           ],
-          "fieldType": "uint64",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              275,
+              12
+            ],
+            "end": [
+              275,
+              17
+            ],
+            "name": "uint64"
+          },
           "name": "int64_number",
           "id": 3,
           "options": [
@@ -2943,7 +3933,18 @@
             44
           ],
           "keyType": "string",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              280,
+              15
+            ],
+            "end": [
+              280,
+              20
+            ],
+            "name": "string"
+          },
           "name": "map_string_string",
           "id": 1
         },
@@ -2958,7 +3959,18 @@
             42
           ],
           "keyType": "string",
-          "valueType": "int32",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              281,
+              15
+            ],
+            "end": [
+              281,
+              19
+            ],
+            "name": "int32"
+          },
           "name": "map_string_int32",
           "id": 2
         },
@@ -2973,7 +3985,18 @@
             42
           ],
           "keyType": "string",
-          "valueType": "int64",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              282,
+              15
+            ],
+            "end": [
+              282,
+              19
+            ],
+            "name": "int64"
+          },
           "name": "map_string_int64",
           "id": 3
         },
@@ -2988,7 +4011,18 @@
             40
           ],
           "keyType": "string",
-          "valueType": "bool",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              283,
+              15
+            ],
+            "end": [
+              283,
+              18
+            ],
+            "name": "bool"
+          },
           "name": "map_string_bool",
           "id": 4
         },
@@ -3003,7 +4037,18 @@
             44
           ],
           "keyType": "string",
-          "valueType": "double",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              284,
+              15
+            ],
+            "end": [
+              284,
+              20
+            ],
+            "name": "double"
+          },
           "name": "map_string_double",
           "id": 5
         },
@@ -3018,7 +4063,18 @@
             56
           ],
           "keyType": "string",
-          "valueType": "MapValueEnumNoBinary",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              285,
+              15
+            ],
+            "end": [
+              285,
+              34
+            ],
+            "name": "MapValueEnumNoBinary"
+          },
           "name": "map_string_enum",
           "id": 6
         },
@@ -3033,7 +4089,18 @@
             58
           ],
           "keyType": "string",
-          "valueType": "MapValueMessageNoBinary",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              286,
+              15
+            ],
+            "end": [
+              286,
+              37
+            ],
+            "name": "MapValueMessageNoBinary"
+          },
           "name": "map_string_msg",
           "id": 7
         },
@@ -3048,7 +4115,18 @@
             42
           ],
           "keyType": "int32",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              288,
+              14
+            ],
+            "end": [
+              288,
+              19
+            ],
+            "name": "string"
+          },
           "name": "map_int32_string",
           "id": 8
         },
@@ -3063,7 +4141,18 @@
             42
           ],
           "keyType": "int64",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              289,
+              14
+            ],
+            "end": [
+              289,
+              19
+            ],
+            "name": "string"
+          },
           "name": "map_int64_string",
           "id": 9
         },
@@ -3078,7 +4167,18 @@
             41
           ],
           "keyType": "bool",
-          "valueType": "string",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              290,
+              13
+            ],
+            "end": [
+              290,
+              18
+            ],
+            "name": "string"
+          },
           "name": "map_bool_string",
           "id": 10
         },
@@ -3092,7 +4192,18 @@
             292,
             54
           ],
-          "fieldType": "TestMapFieldsNoBinary",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              292,
+              12
+            ],
+            "end": [
+              292,
+              32
+            ],
+            "name": "TestMapFieldsNoBinary"
+          },
           "name": "test_map_fields",
           "id": 11,
           "options": [],
@@ -3111,7 +4222,18 @@
             67
           ],
           "keyType": "string",
-          "valueType": "TestMapFieldsNoBinary",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              293,
+              15
+            ],
+            "end": [
+              293,
+              35
+            ],
+            "name": "TestMapFieldsNoBinary"
+          },
           "name": "map_string_testmapfields",
           "id": 12
         }
@@ -3192,7 +4314,18 @@
             303,
             25
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              303,
+              12
+            ],
+            "end": [
+              303,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "foo",
           "id": 1,
           "options": [],
@@ -3248,7 +4381,18 @@
                     309,
                     31
                   ],
-                  "fieldType": "int32",
+                  "fieldType": {
+                    "type": "Type",
+                    "start": [
+                      309,
+                      16
+                    ],
+                    "end": [
+                      309,
+                      20
+                    ],
+                    "name": "int32"
+                  },
                   "name": "count",
                   "id": 1,
                   "options": [],

--- a/testdata/test10.ast.json
+++ b/testdata/test10.ast.json
@@ -69,7 +69,18 @@
             38,
             43
           ],
-          "fieldType": "jspb.exttest.strict.nine.Simple9",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              38,
+              5
+            ],
+            "end": [
+              38,
+              36
+            ],
+            "name": "jspb.exttest.strict.nine.Simple9"
+          },
           "name": "a",
           "id": 1,
           "options": [],

--- a/testdata/test11.ast.json
+++ b/testdata/test11.ast.json
@@ -67,7 +67,18 @@
                 37,
                 25
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  37,
+                  14
+                ],
+                "end": [
+                  37,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "a",
               "id": 1,
               "options": [],
@@ -111,7 +122,18 @@
                     41,
                     27
                   ],
-                  "fieldType": "int32",
+                  "fieldType": {
+                    "type": "Type",
+                    "start": [
+                      41,
+                      16
+                    ],
+                    "end": [
+                      41,
+                      20
+                    ],
+                    "name": "int32"
+                  },
                   "name": "b",
                   "id": 2,
                   "options": [],
@@ -147,7 +169,18 @@
             47,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              47,
+              12
+            ],
+            "end": [
+              47,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "c",
           "id": 3,
           "options": [],

--- a/testdata/test12.ast.json
+++ b/testdata/test12.ast.json
@@ -55,7 +55,18 @@
             37,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              37,
+              12
+            ],
+            "end": [
+              37,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -73,7 +84,18 @@
             38,
             31
           ],
-          "fieldType": "MessageField2",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              38,
+              12
+            ],
+            "end": [
+              38,
+              24
+            ],
+            "name": "MessageField2"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -105,7 +127,18 @@
             42,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              42,
+              12
+            ],
+            "end": [
+              42,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -123,7 +156,18 @@
             43,
             31
           ],
-          "fieldType": "MessageField1",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              43,
+              12
+            ],
+            "end": [
+              43,
+              24
+            ],
+            "name": "MessageField1"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -155,7 +199,18 @@
             48,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              48,
+              12
+            ],
+            "end": [
+              48,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -173,7 +228,18 @@
             49,
             39
           ],
-          "fieldType": "RepeatedMessageField2",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              49,
+              12
+            ],
+            "end": [
+              49,
+              32
+            ],
+            "name": "RepeatedMessageField2"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -205,7 +271,18 @@
             53,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              53,
+              12
+            ],
+            "end": [
+              53,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -223,7 +300,18 @@
             54,
             39
           ],
-          "fieldType": "RepeatedMessageField1",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              54,
+              12
+            ],
+            "end": [
+              54,
+              32
+            ],
+            "name": "RepeatedMessageField1"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -255,7 +343,18 @@
             58,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              58,
+              12
+            ],
+            "end": [
+              58,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -273,7 +372,18 @@
             59,
             27
           ],
-          "fieldType": "MapField2",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              59,
+              12
+            ],
+            "end": [
+              59,
+              20
+            ],
+            "name": "MapField2"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -305,7 +415,18 @@
             63,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              63,
+              12
+            ],
+            "end": [
+              63,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -324,7 +445,18 @@
             30
           ],
           "keyType": "int32",
-          "valueType": "MapField1",
+          "valueType": {
+            "type": "Type",
+            "start": [
+              64,
+              14
+            ],
+            "end": [
+              64,
+              22
+            ],
+            "name": "MapField1"
+          },
           "name": "b",
           "id": 2
         }
@@ -352,7 +484,18 @@
             68,
             32
           ],
-          "fieldType": "NestedMessage2",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              68,
+              12
+            ],
+            "end": [
+              68,
+              25
+            ],
+            "name": "NestedMessage2"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -382,7 +525,18 @@
                 70,
                 25
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  70,
+                  14
+                ],
+                "end": [
+                  70,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "a",
               "id": 1,
               "options": [],
@@ -416,7 +570,18 @@
             75,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              75,
+              12
+            ],
+            "end": [
+              75,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -434,7 +599,18 @@
             76,
             52
           ],
-          "fieldType": "NestedMessage1.NestedNestedMessage",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              76,
+              12
+            ],
+            "end": [
+              76,
+              45
+            ],
+            "name": "NestedMessage1.NestedNestedMessage"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -466,7 +642,18 @@
             80,
             29
           ],
-          "fieldType": "NestedEnum2",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              80,
+              12
+            ],
+            "end": [
+              80,
+              22
+            ],
+            "name": "NestedEnum2"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -538,7 +725,18 @@
             88,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              88,
+              12
+            ],
+            "end": [
+              88,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -556,7 +754,18 @@
             89,
             46
           ],
-          "fieldType": "NestedEnum1.NestedNestedEnum",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              89,
+              12
+            ],
+            "end": [
+              89,
+              39
+            ],
+            "name": "NestedEnum1.NestedNestedEnum"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -588,7 +797,18 @@
             93,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              93,
+              12
+            ],
+            "end": [
+              93,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -606,7 +826,18 @@
             94,
             42
           ],
-          "fieldType": "ExtensionContainingType2",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              94,
+              12
+            ],
+            "end": [
+              94,
+              35
+            ],
+            "name": "ExtensionContainingType2"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -655,7 +886,18 @@
             99,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              99,
+              12
+            ],
+            "end": [
+              99,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -685,7 +927,18 @@
                 101,
                 26
               ],
-              "fieldType": "int32",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  101,
+                  14
+                ],
+                "end": [
+                  101,
+                  18
+                ],
+                "name": "int32"
+              },
               "name": "c",
               "id": 99,
               "options": [],
@@ -719,7 +972,18 @@
             106,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              106,
+              12
+            ],
+            "end": [
+              106,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -737,7 +1001,18 @@
             107,
             33
           ],
-          "fieldType": "ExtensionField2",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              107,
+              12
+            ],
+            "end": [
+              107,
+              26
+            ],
+            "name": "ExtensionField2"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -769,7 +1044,18 @@
             111,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              111,
+              12
+            ],
+            "end": [
+              111,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -799,7 +1085,18 @@
                 113,
                 36
               ],
-              "fieldType": "ExtensionField1",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  113,
+                  14
+                ],
+                "end": [
+                  113,
+                  28
+                ],
+                "name": "ExtensionField1"
+              },
               "name": "c",
               "id": 99,
               "options": [],

--- a/testdata/test13.ast.json
+++ b/testdata/test13.ast.json
@@ -86,7 +86,18 @@
             40,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              40,
+              12
+            ],
+            "end": [
+              40,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -158,7 +169,18 @@
             50,
             12
           ],
-          "fieldType": "TestLooooooooooooooooooooooooooooooooooooooooooooooooooooooongName2",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              49,
+              12
+            ],
+            "end": [
+              49,
+              78
+            ],
+            "name": "TestLooooooooooooooooooooooooooooooooooooooooooooooooooooooongName2"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -176,7 +198,18 @@
             51,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              51,
+              12
+            ],
+            "end": [
+              51,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -208,7 +241,18 @@
             56,
             12
           ],
-          "fieldType": "TestLooooooooooooooooooooooooooooooooooooooooooooooooooooooongName3",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              55,
+              12
+            ],
+            "end": [
+              55,
+              78
+            ],
+            "name": "TestLooooooooooooooooooooooooooooooooooooooooooooooooooooooongName3"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -226,7 +270,18 @@
             57,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              57,
+              12
+            ],
+            "end": [
+              57,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -258,7 +313,18 @@
             62,
             12
           ],
-          "fieldType": "TestLooooooooooooooooooooooooooooooooooooooooooooooooooooooongName4",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              61,
+              12
+            ],
+            "end": [
+              61,
+              78
+            ],
+            "name": "TestLooooooooooooooooooooooooooooooooooooooooooooooooooooooongName4"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -276,7 +342,18 @@
             63,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              63,
+              12
+            ],
+            "end": [
+              63,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "b",
           "id": 2,
           "options": [],
@@ -308,7 +385,18 @@
             68,
             12
           ],
-          "fieldType": "TestLooooooooooooooooooooooooooooooooooooooooooooooooooooooongName1",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              67,
+              12
+            ],
+            "end": [
+              67,
+              78
+            ],
+            "name": "TestLooooooooooooooooooooooooooooooooooooooooooooooooooooooongName1"
+          },
           "name": "a",
           "id": 1,
           "options": [],
@@ -326,7 +414,18 @@
             69,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              69,
+              12
+            ],
+            "end": [
+              69,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "b",
           "id": 2,
           "options": [],

--- a/testdata/test14.ast.json
+++ b/testdata/test14.ast.json
@@ -55,7 +55,18 @@
             36,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              36,
+              12
+            ],
+            "end": [
+              36,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "a",
           "id": 1,
           "options": [],

--- a/testdata/test15.ast.json
+++ b/testdata/test15.ast.json
@@ -69,7 +69,18 @@
             38,
             23
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              38,
+              12
+            ],
+            "end": [
+              38,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "b",
           "id": 2,
           "options": [],

--- a/testdata/test2.ast.json
+++ b/testdata/test2.ast.json
@@ -127,7 +127,18 @@
             41,
             30
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              41,
+              12
+            ],
+            "end": [
+              41,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "intfield",
           "id": 1,
           "options": [],
@@ -188,7 +199,18 @@
                 47,
                 46
               ],
-              "fieldType": "ExtensionMessage",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  47,
+                  14
+                ],
+                "end": [
+                  47,
+                  29
+                ],
+                "name": "ExtensionMessage"
+              },
               "name": "ext_field",
               "id": 100,
               "options": [],
@@ -208,7 +230,18 @@
             49,
             27
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              49,
+              12
+            ],
+            "end": [
+              49,
+              17
+            ],
+            "name": "string"
+          },
           "name": "ext1",
           "id": 1,
           "options": [],
@@ -240,7 +273,18 @@
             54,
             53
           ],
-          "fieldType": "ExtensionMessage",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              54,
+              12
+            ],
+            "end": [
+              54,
+              27
+            ],
+            "name": "ExtensionMessage"
+          },
           "name": "floating_msg_field",
           "id": 101,
           "options": [],
@@ -258,7 +302,18 @@
             55,
             43
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              55,
+              12
+            ],
+            "end": [
+              55,
+              17
+            ],
+            "name": "string"
+          },
           "name": "floating_str_field",
           "id": 102,
           "options": [],
@@ -290,7 +345,18 @@
             59,
             59
           ],
-          "fieldType": "Deeply.Nested.Message",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              59,
+              12
+            ],
+            "end": [
+              59,
+              32
+            ],
+            "name": "Deeply.Nested.Message"
+          },
           "name": "deeply_nested_message",
           "id": 1,
           "options": [],

--- a/testdata/test3.ast.json
+++ b/testdata/test3.ast.json
@@ -113,7 +113,18 @@
             39,
             30
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              39,
+              12
+            ],
+            "end": [
+              39,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "intfield",
           "id": 1,
           "options": [],
@@ -174,7 +185,18 @@
                 45,
                 46
               ],
-              "fieldType": "ExtensionMessage",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  45,
+                  14
+                ],
+                "end": [
+                  45,
+                  29
+                ],
+                "name": "ExtensionMessage"
+              },
               "name": "ext_field",
               "id": 100,
               "options": [],
@@ -194,7 +216,18 @@
             47,
             27
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              47,
+              12
+            ],
+            "end": [
+              47,
+              17
+            ],
+            "name": "string"
+          },
           "name": "ext1",
           "id": 1,
           "options": [],
@@ -226,7 +259,18 @@
             51,
             53
           ],
-          "fieldType": "ExtensionMessage",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              51,
+              12
+            ],
+            "end": [
+              51,
+              27
+            ],
+            "name": "ExtensionMessage"
+          },
           "name": "floating_msg_field",
           "id": 101,
           "options": [],
@@ -244,7 +288,18 @@
             52,
             43
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              52,
+              12
+            ],
+            "end": [
+              52,
+              17
+            ],
+            "name": "string"
+          },
           "name": "floating_str_field",
           "id": 102,
           "options": [],

--- a/testdata/test4.ast.json
+++ b/testdata/test4.ast.json
@@ -127,7 +127,18 @@
             41,
             57
           ],
-          "fieldType": "ExtensionMessage",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              41,
+              12
+            ],
+            "end": [
+              41,
+              27
+            ],
+            "name": "ExtensionMessage"
+          },
           "name": "floating_msg_field_two",
           "id": 103,
           "options": [],

--- a/testdata/test5.ast.json
+++ b/testdata/test5.ast.json
@@ -144,7 +144,18 @@
             43,
             43
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              43,
+              12
+            ],
+            "end": [
+              43,
+              17
+            ],
+            "name": "string"
+          },
           "name": "floating_str_field",
           "id": 101,
           "options": [],

--- a/testdata/test8.ast.json
+++ b/testdata/test8.ast.json
@@ -113,7 +113,18 @@
             39,
             30
           ],
-          "fieldType": "int32",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              39,
+              12
+            ],
+            "end": [
+              39,
+              16
+            ],
+            "name": "int32"
+          },
           "name": "intfield",
           "id": 1,
           "options": [],
@@ -174,7 +185,18 @@
                 45,
                 29
               ],
-              "fieldType": "string",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  45,
+                  14
+                ],
+                "end": [
+                  45,
+                  19
+                ],
+                "name": "string"
+              },
               "name": "ext1",
               "id": 1,
               "options": [],
@@ -206,7 +228,18 @@
                 48,
                 58
               ],
-              "fieldType": "NestedExtensionMessage",
+              "fieldType": {
+                "type": "Type",
+                "start": [
+                  48,
+                  14
+                ],
+                "end": [
+                  48,
+                  35
+                ],
+                "name": "NestedExtensionMessage"
+              },
               "name": "inner_extension",
               "id": 100,
               "options": [],

--- a/testdata/test9.ast.json
+++ b/testdata/test9.ast.json
@@ -55,7 +55,18 @@
             36,
             31
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              36,
+              12
+            ],
+            "end": [
+              36,
+              17
+            ],
+            "name": "string"
+          },
           "name": "a_string",
           "id": 1,
           "options": [],
@@ -73,7 +84,18 @@
             37,
             40
           ],
-          "fieldType": "string",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              37,
+              12
+            ],
+            "end": [
+              37,
+              17
+            ],
+            "name": "string"
+          },
           "name": "a_repeated_string",
           "id": 2,
           "options": [],
@@ -91,7 +113,18 @@
             38,
             30
           ],
-          "fieldType": "bool",
+          "fieldType": {
+            "type": "Type",
+            "start": [
+              38,
+              12
+            ],
+            "end": [
+              38,
+              15
+            ],
+            "name": "bool"
+          },
           "name": "a_boolean",
           "id": 3,
           "options": [],

--- a/type.ts
+++ b/type.ts
@@ -49,10 +49,12 @@ export class Type extends ParseNode {
       await scanner.scan();
     }
     const start = scanner.startPos;
-    let name = scanner.contents;
-    if (name === ".") {
-      name += await expectFullIdent(scanner);
+    let name = "";
+    if (scanner.contents === ".") {
+      name += ".";
+      await scanner.scan();
     }
+    name += await expectFullIdent(scanner, false);
     return new Type(name, start, scanner.endPos);
   }
 }

--- a/type.ts
+++ b/type.ts
@@ -1,6 +1,7 @@
 import { ParseNode } from "./parsenode.ts";
 import { Visitor } from "./visitor.ts";
-import { Scanner } from "./deps.ts";
+import { Scanner, Token } from "./deps.ts";
+import { expectFullIdent } from "./util.ts";
 
 /**
  * Represents a Type.
@@ -43,5 +44,15 @@ export class Type extends ParseNode {
     visitor.visitType?.(this);
   }
 
-  static async parse(scanner: Scanner): Promise<Type>;
+  static async parse(scanner: Scanner): Promise<Type> {
+    if (scanner.currentToken !== Token.identifier && scanner.contents !== ".") {
+      await scanner.scan();
+    }
+    const start = scanner.startPos;
+    let name = scanner.contents;
+    if (name === ".") {
+      name += await expectFullIdent(scanner);
+    }
+    return new Type(name, start, scanner.endPos);
+  }
 }

--- a/type.ts
+++ b/type.ts
@@ -1,0 +1,47 @@
+import { ParseNode } from "./parsenode.ts";
+import { Visitor } from "./visitor.ts";
+import { Scanner } from "./deps.ts";
+
+/**
+ * Represents a Type.
+ *
+ * https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#fields
+ */
+export class Type extends ParseNode {
+  constructor(
+    /**
+     * The name of a type.
+     */
+    public name: string,
+    /**
+     * The starting [line, column]
+     */
+    public start: [number, number] = [0, 0],
+    /**
+     * The ending [line, column]
+     */
+    public end: [number, number] = [0, 0],
+  ) {
+    super();
+  }
+
+  toProto() {
+    return this.name;
+  }
+
+  toJSON() {
+    return {
+      type: "Type",
+      start: this.start,
+      end: this.end,
+      name: this.name,
+    };
+  }
+
+  accept(visitor: Visitor) {
+    visitor.visit?.(this);
+    visitor.visitType?.(this);
+  }
+
+  static async parse(scanner: Scanner): Promise<Type>;
+}

--- a/type_test.ts
+++ b/type_test.ts
@@ -1,0 +1,45 @@
+import { assertNode, assertNodeThrows } from "./testutil.ts";
+import { Type } from "./type.ts";
+
+Deno.test("Type", async () => {
+  const tt: [string, Type, 2 | 3][] = [
+    [
+      `float`,
+      new Type(
+        "float",
+        [1, 1],
+        [1, 5],
+      ),
+      2,
+    ],
+    [
+      `.Foo`,
+      new Type(
+        ".Foo",
+        [1, 1],
+        [1, 4],
+      ),
+      2,
+    ],
+    [
+      `foo.bar`,
+      new Type(
+        "foo.bar",
+        [1, 1],
+        [1, 7],
+      ),
+      3,
+    ],
+  ];
+  for (const t of tt) await assertNode(Type, ...t);
+});
+
+Deno.test("Type errors", async () => {
+  const tt: [string, string][] = [
+    [
+      `foo..bar`,
+      "unexpected token (.) on line 1, column 5; expected identifier",
+    ],
+  ];
+  for (const t of tt) await assertNodeThrows(Type, ...t);
+});

--- a/visitor.ts
+++ b/visitor.ts
@@ -18,6 +18,7 @@ import type { RPC } from "./rpc.ts";
 import type { Reserved } from "./reserved.ts";
 import type { Service } from "./service.ts";
 import type { Syntax } from "./syntax.ts";
+import type { Type } from "./type.ts";
 import type { Comment } from "./comment.ts";
 
 /**
@@ -106,6 +107,10 @@ export interface Visitor {
    * This will be called for every Syntax Node in the AST.
    */
   visitSyntax?: (node: Syntax) => void;
+  /**
+   * This will be called for every Type Node in the AST.
+   */
+  visitType?: (node: Type) => void;
   /**
    * This will be called for every Comment Node in the AST.
    */


### PR DESCRIPTION
The scanner consumes too much: https://github.com/keithamus/deno-protoc-parser/runs/1130944246

My proposal:

* Change the definition of `isIdent` to match only `ident` and `fullIdent`
* Add a class for parsing type names, including user-defined ones