### PR TITLE
fix: keywords 'stream' before identifier.

### DIFF
--- a/rpc.ts
+++ b/rpc.ts
@@ -115,6 +115,7 @@ export class RPC extends ParseNode {
       streaming: false,
     };
     if (request.name.name === "stream") {
+      await nextTokenIs(scanner, Token.identifier);
       request.streaming = true;
       request.name = await Type.parse(scanner);
     }
@@ -126,6 +127,7 @@ export class RPC extends ParseNode {
       streaming: false,
     };
     if (response.name.name === "stream") {
+      await nextTokenIs(scanner, Token.identifier);
       response.streaming = true;
       response.name = await Type.parse(scanner);
     }

--- a/rpc_test.ts
+++ b/rpc_test.ts
@@ -35,7 +35,7 @@ Deno.test("RPC", async () => {
         null,
         [1, 1],
         [1, 35],
-      )
+      ),
     ],
     [
       `rpc Foo (Req) returns (stream Res);`,
@@ -46,8 +46,8 @@ Deno.test("RPC", async () => {
         null,
         [1, 1],
         [1, 35],
-      )
-    ]
+      ),
+    ],
   ];
   for (const t of tt) await assertNode(RPC, ...t);
 });

--- a/rpc_test.ts
+++ b/rpc_test.ts
@@ -26,6 +26,28 @@ Deno.test("RPC", async () => {
         [1, 28],
       ),
     ],
+    [
+      `rpc Foo (stream Req) returns (Res);`,
+      new RPC(
+        "Foo",
+        { name: new Type("Req", [1, 17], [1, 19]), streaming: true },
+        { name: new Type("Res", [1, 31], [1, 33]) },
+        null,
+        [1, 1],
+        [1, 35],
+      )
+    ],
+    [
+      `rpc Foo (Req) returns (stream Res);`,
+      new RPC(
+        "Foo",
+        { name: new Type("Req", [1, 10], [1, 12]) },
+        { name: new Type("Res", [1, 31], [1, 33]), streaming: true },
+        null,
+        [1, 1],
+        [1, 35],
+      )
+    ]
   ];
   for (const t of tt) await assertNode(RPC, ...t);
 });


### PR DESCRIPTION
Hi, I got these errors by using the keywords `stream` before the identifier.

```shell
`rpc Foo (stream Req) returns (Res);`
SyntaxError: unexpected identifier (Req) on line 1, column 17
    throw new TokenError(scanner, actualToken, expectedToken, expectedContents);

`rpc Foo (Req) returns (stream Res);`
SyntaxError: unexpected identifier (Res) on line 1, column 31
    throw new TokenError(scanner, actualToken, expectedToken, expectedContents);
```